### PR TITLE
feat(symbolic): add multi-variable constraints and joint satisfiability

### DIFF
--- a/src/fhy_core/symbolic/constraint.py
+++ b/src/fhy_core/symbolic/constraint.py
@@ -36,8 +36,13 @@ Every constraint additionally supports a *bindings* evaluation API --
 the constraint against a ``Mapping[Identifier, value]`` instead of a single
 positional value. This makes multi-variable (dependent) constraints
 usable: an ``EquationConstraint`` whose expression mentions identifiers
-beyond ``self.variable`` is decided once every identifier it references
-is bound. ``ConstraintSystem`` is the companion set-level value object: a
+beyond ``self.variable`` becomes decidable once every identifier it
+references is bound to a literal. Decidable is not decided: binding an
+identifier to a non-literal, symbolic ``Expression`` leaves a residual
+over the identifiers that expression introduces, and even a fully
+literal assignment can leave a residual the simplifier cannot reduce to
+a literal. Either case reports ``UNDECIDED``.
+``ConstraintSystem`` is the companion set-level value object: a
 canonically ordered conjunction of constraints, possibly spanning several
 variables, with joint-satisfiability checking backed by
 ``fhy_core.symbolic.solver.check_expression_satisfiability``. It is not a
@@ -131,22 +136,64 @@ ConstraintBindings: TypeAlias = Mapping[Identifier, "Expression | LiteralType"]
 """Assignment of candidate values (literals or expressions) to identifiers."""
 
 
+def _validate_binding_value(identifier: Identifier, value: object) -> None:
+    """Reject a binding value ``ConstraintBindings`` does not admit.
+
+    ``ConstraintBindings`` is public and declares ``Expression |
+    LiteralType``. A value in neither arm cannot be lifted into a
+    substitution environment, and handing it to the expression passes
+    anyway surfaces as an internal pass failure that names no identifier.
+    Rejecting it here reports the caller's mistake as a domain error
+    instead.
+
+    Args:
+        identifier: Identifier the value is bound to.
+        value: Candidate binding value.
+
+    Raises:
+        ConstraintError: If ``value`` is neither an ``Expression`` nor a
+            ``LiteralType``. The message names the identifier, the value,
+            and the value's type.
+
+    """
+    if isinstance(value, (Expression, LiteralType)):
+        return
+    raise ConstraintError(
+        f"Binding for identifier {identifier!r} must be an `Expression` or a "
+        f"literal (`str`, `float`, `int`, `bool`), but got value {value!r} of "
+        f"type {type(value).__name__}."
+    )
+
+
 def _coerce_bindings_to_environment(
     bindings: ConstraintBindings,
 ) -> dict[Identifier, Expression]:
-    """Coerce every raw ``LiteralType`` binding value to a ``LiteralExpression``.
+    """Coerce every binding value to the ``Expression`` a substitution consumes.
 
-    ``Expression`` values (including a non-literal, symbolic ``Expression``)
-    pass through unchanged.
+    A raw ``LiteralType`` value is wrapped in a ``LiteralExpression``. An
+    ``Expression`` value passes through unchanged, including a non-literal,
+    symbolic one: substituting a symbolic value is supported, and the
+    residual it leaves behind is what the caller's outcome is read from.
+
+    Args:
+        bindings: Mapping from identifiers to candidate values.
+
+    Returns:
+        Substitution environment binding each identifier to an
+        ``Expression``.
+
+    Raises:
+        ConstraintError: If a value falls outside ``Expression |
+            LiteralType``.
+
     """
-    return {
-        identifier: (
-            LiteralExpression(value)
-            if isinstance(value, (str, float, int, bool))
-            else value
+    environment: dict[Identifier, Expression] = {}
+    for identifier, value in bindings.items():
+        _validate_binding_value(identifier, value)
+        environment[identifier] = (
+            value if isinstance(value, Expression) else LiteralExpression(value)
         )
-        for identifier, value in bindings.items()
-    }
+    return environment
 
 
 @register_error
@@ -614,6 +661,18 @@ class Constraint(
         never reports ``UNDECIDED`` and so gives no other clue which of
         the two occurred.
 
+        A value outside the declared ``Expression | LiteralType`` union
+        reaches ``evaluate`` unchanged rather than being turned away: this
+        implementation has no expression to lift the value into, and
+        ``evaluate`` accepts ``Any``, so a hashable off-union value is
+        simply not a member and the check stays decided, while an
+        unhashable one raises the ``TypeError`` below.
+        ``EquationConstraint.evaluate_with_bindings`` cannot forward a
+        value -- it has to build a substitution environment out of it --
+        and rejects an off-union value with ``ConstraintError``. The two
+        paths agree on what matters: neither lets a failure from the
+        expression passes escape as the caller's answer.
+
         Args:
             bindings: Mapping from identifiers to candidate values. Raw
                 ``LiteralType`` values and ``Expression`` values are both
@@ -625,9 +684,11 @@ class Constraint(
             (possibly partial) bindings; ``UNDECIDED`` otherwise.
 
         Raises:
-            TypeError: Propagated from ``evaluate`` for leaves that reject
-                the bound value's type (e.g. an unhashable value against a
-                set constraint).
+            TypeError: Propagated from this implementation's call to
+                ``evaluate`` for leaves that reject the bound value's type
+                (e.g. an unhashable value against a set constraint). An
+                override that never calls ``evaluate`` documents its own
+                failure modes instead.
 
         """
         snapshot = dict(bindings)
@@ -763,6 +824,19 @@ class EquationConstraint(Constraint):
         WARNING when the residual has none -- every free identifier was
         bound yet the simplifier still failed to reduce it to a literal
         (matches ``evaluate``'s anomaly contract).
+
+        This override never calls ``evaluate``, so the base's ``TypeError``
+        does not apply; its own failure modes are below.
+
+        Raises:
+            ConstraintError: If a binding value falls outside
+                ``Expression | LiteralType`` and so cannot be lifted into
+                the substitution environment.
+            ValueError: From ``LiteralExpression`` when a ``str`` binding
+                value matches neither the integer nor the float grammar.
+            PassExecutionError: Propagated from ``simplify_expression``
+                when the SymPy bridge fails to lower or lift the
+                substituted expression.
 
         """
         environment = _coerce_bindings_to_environment(bindings)
@@ -1662,7 +1736,13 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
         as the whole expression, lowers faithfully and stays decidable.
 
         Args:
-            symbol_types: Z3 sort for each free identifier of the system.
+            symbol_types: Z3 sort for each free identifier of the lowered
+                conjunction. That set can be strictly smaller than
+                ``get_free_identifiers()``: an ``EquationConstraint``
+                reports its ``variable`` as free whether or not its
+                expression references it, while ``convert_to_expression``
+                emits only the expression, so an unreferenced ``variable``
+                needs no entry.
             timeout_milliseconds: Optional bound, in milliseconds, on the
                 underlying Z3 solver invocation. ``None`` (the default)
                 leaves the solver unbounded.
@@ -1722,7 +1802,9 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
 
         Args:
             bindings: Partial assignment substituted into the conjunction
-                before the satisfiability check.
+                before the satisfiability check. Values must be
+                ``Expression`` or ``LiteralType``, as
+                ``ConstraintBindings`` declares.
             symbol_types: Z3 sort for each identifier left free after
                 substitution.
             timeout_milliseconds: Optional bound, in milliseconds, on the
@@ -1743,6 +1825,9 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
                 a missing symbol type here always raises, since the Z3
                 bridge cannot proceed without a sort for every free
                 identifier.
+            ConstraintError: If a member cannot be converted to an
+                expression, or if a ``bindings`` value falls outside
+                ``Expression | LiteralType``.
             ValueError: If ``timeout_milliseconds`` is not None and not
                 positive. Checked before the empty-system and hazard
                 early returns, so an inadmissible bound is rejected even

--- a/src/fhy_core/symbolic/constraint.py
+++ b/src/fhy_core/symbolic/constraint.py
@@ -64,6 +64,7 @@ __all__ = [
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Hashable, Iterator, Mapping
 from dataclasses import dataclass, field
+from decimal import Decimal
 from enum import Enum, auto
 from typing import (
     TYPE_CHECKING,
@@ -103,10 +104,16 @@ from fhy_core.traits import FrozenMixin
 from fhy_core.utils import format_comma_separated_list
 
 from .expression import (
+    BinaryExpression,
     BinaryOperation,
+    CallExpression,
     Expression,
+    IdentifierExpression,
     LiteralExpression,
     LiteralType,
+    PiecewiseExpression,
+    UnaryExpression,
+    UnaryOperation,
     make_binary_expression,
     pformat_expression,
 )
@@ -738,15 +745,34 @@ class EquationConstraint(Constraint):
 
 
 def _render_member_set(members: frozenset[_TypedMember]) -> str:
-    rendered_members = format_comma_separated_list(
-        sorted((_unwrap_member(member) for member in members), key=repr),
+    """Render the members in ``repr`` form, sorted, inside set braces.
+
+    ``repr`` is applied to every member including a ``str`` member, so the
+    string ``"5"`` renders as ``'5'`` while the integer ``5`` renders as
+    ``5``. Membership is type-strict, so the two are different members and
+    the textual form has to keep them apart.
+
+    """
+    rendered_members = ", ".join(
+        sorted(repr(_unwrap_member(member)) for member in members)
     )
     return f"{{{rendered_members}}}"
 
 
 def _render_member_set_str(members: frozenset[_TypedMember]) -> str:
-    rendered_members = format_comma_separated_list(
-        (_unwrap_member(member) for member in members), str_func=str
+    """Render the members in human-readable form, sorted, inside set braces.
+
+    A ``str`` member is quoted so it stays distinguishable from the
+    numeric member carrying the same digits, matching the type-strict
+    membership semantics. Rendering is sorted so the textual form does not
+    depend on set iteration order.
+
+    """
+    rendered_members = ", ".join(
+        sorted(
+            repr(value) if isinstance(value, str) else str(value)
+            for value in (_unwrap_member(member) for member in members)
+        )
     )
     return f"{{{rendered_members}}}"
 
@@ -964,6 +990,197 @@ def _validate_symbol_types_cover_free_identifiers(
     )
 
 
+class _LoweredSort(Enum):
+    """Z3 sort an expression node lowers to, as far as it can be determined.
+
+    ``UNDETERMINED`` covers the nodes whose lowered sort this module
+    cannot read off the tree: an identifier with no ``symbol_types``
+    entry, a call (which the Z3 bridge refuses outright), an unrecognized
+    ``Expression`` subclass, and a piecewise whose branches disagree.
+    """
+
+    BOOLEAN = auto()
+    NUMERIC = auto()
+    UNDETERMINED = auto()
+
+
+_NUMERIC_BINARY_OPERATIONS: frozenset[BinaryOperation] = frozenset(
+    {
+        BinaryOperation.ADD,
+        BinaryOperation.SUBTRACT,
+        BinaryOperation.MULTIPLY,
+        BinaryOperation.DIVIDE,
+        BinaryOperation.FLOOR_DIVIDE,
+        BinaryOperation.MODULO,
+        BinaryOperation.POWER,
+    }
+)
+"""Binary operations the Z3 bridge lowers to arithmetic on a numeric sort."""
+
+_COMPARISON_BINARY_OPERATIONS: frozenset[BinaryOperation] = frozenset(
+    {
+        BinaryOperation.EQUAL,
+        BinaryOperation.NOT_EQUAL,
+        BinaryOperation.LESS,
+        BinaryOperation.LESS_EQUAL,
+        BinaryOperation.GREATER,
+        BinaryOperation.GREATER_EQUAL,
+    }
+)
+"""Binary operations the Z3 bridge lowers to a comparison of two operands."""
+
+_LOGICAL_BINARY_OPERATIONS: frozenset[BinaryOperation] = frozenset(
+    {BinaryOperation.LOGICAL_AND, BinaryOperation.LOGICAL_OR}
+)
+"""Binary operations the Z3 bridge lowers to ``z3.And``/``z3.Or``."""
+
+
+# One early return per node kind reads clearest here; the alternative is a
+# lookup table that would have to be threaded through `symbol_types` anyway.
+def _classify_lowered_sort(  # noqa: PLR0911
+    expression: Expression, symbol_types: Mapping[Identifier, SymbolType]
+) -> _LoweredSort:
+    """Return the Z3 sort ``expression`` lowers to, per ``passes.z3``.
+
+    Mirrors ``ExpressionToZ3Converter``: a ``bool``-valued literal becomes
+    a ``BoolVal`` and every other literal an ``IntVal``/``RealVal``; an
+    identifier takes the sort named by its ``symbol_types`` entry; a
+    comparison, a logical operation, and a logical negation are Boolean;
+    arithmetic is numeric; a piecewise takes the sort its branches agree
+    on.
+
+    Args:
+        expression: Node whose lowered sort is wanted.
+        symbol_types: Z3 sort for each identifier of the enclosing
+            expression.
+
+    Returns:
+        The node's ``_LoweredSort``.
+
+    """
+    if isinstance(expression, LiteralExpression):
+        if type(expression.value) is bool:
+            return _LoweredSort.BOOLEAN
+        return _LoweredSort.NUMERIC
+    elif isinstance(expression, IdentifierExpression):
+        symbol_type = symbol_types.get(expression.identifier)
+        if symbol_type is SymbolType.BOOL:
+            return _LoweredSort.BOOLEAN
+        elif symbol_type is None:
+            return _LoweredSort.UNDETERMINED
+        return _LoweredSort.NUMERIC
+    elif isinstance(expression, BinaryExpression):
+        if expression.operation in _NUMERIC_BINARY_OPERATIONS:
+            return _LoweredSort.NUMERIC
+        elif expression.operation in (
+            _COMPARISON_BINARY_OPERATIONS | _LOGICAL_BINARY_OPERATIONS
+        ):
+            return _LoweredSort.BOOLEAN
+        return _LoweredSort.UNDETERMINED
+    elif isinstance(expression, UnaryExpression):
+        if expression.operation is UnaryOperation.LOGICAL_NOT:
+            return _LoweredSort.BOOLEAN
+        return _LoweredSort.NUMERIC
+    elif isinstance(expression, PiecewiseExpression):
+        return _join_lowered_sorts(
+            _classify_lowered_sort(branch, symbol_types)
+            for branch in (*expression.values, expression.otherwise)
+        )
+    elif isinstance(expression, CallExpression):
+        return _LoweredSort.UNDETERMINED
+    return _LoweredSort.UNDETERMINED
+
+
+def _join_lowered_sorts(sorts: Iterator[_LoweredSort]) -> _LoweredSort:
+    """Return the sort every input agrees on, or ``UNDETERMINED`` if they differ."""
+    distinct = set(sorts)
+    if len(distinct) == 1:
+        return distinct.pop()
+    return _LoweredSort.UNDETERMINED
+
+
+def _does_node_coerce_a_bool_operand(
+    expression: Expression, symbol_types: Mapping[Identifier, SymbolType]
+) -> bool:
+    """Return whether this one node makes Z3 coerce a Boolean operand to an integer.
+
+    The Z3 Python bindings rewrite a Boolean operand of a numeric context
+    into ``If(b, 1, 0)``: ``True`` becomes ``1`` and ``False`` becomes
+    ``0``. That collapses the type-strict distinction this module's
+    ``evaluate``/``evaluate_with_bindings`` preserve, so a decided outcome
+    read back through such a lowering can be provably wrong.
+
+    Three contexts coerce:
+
+    - An arithmetic operation with any Boolean operand.
+    - A comparison whose two operands mix a Boolean and a numeric sort. A
+      comparison of two Booleans lowers faithfully and is not flagged.
+    - A piecewise whose branch values mix a Boolean and a numeric sort,
+      since ``z3.If`` forces its two arms to a single sort.
+
+    ``z3.And``/``z3.Or``/``z3.Not`` and unary arithmetic negation do not
+    coerce: they raise on an operand of the wrong sort rather than
+    silently reinterpreting it, so a Boolean there is either correct or
+    already an error.
+
+    Args:
+        expression: Node to screen. Children are not visited.
+        symbol_types: Z3 sort for each identifier of the enclosing
+            expression.
+
+    Returns:
+        True if this node's own lowering coerces a Boolean operand.
+
+    """
+    if isinstance(expression, BinaryExpression):
+        operand_sorts = {
+            _classify_lowered_sort(operand, symbol_types)
+            for operand in expression.get_operands()
+        }
+        if expression.operation in _NUMERIC_BINARY_OPERATIONS:
+            return _LoweredSort.BOOLEAN in operand_sorts
+        elif expression.operation in _COMPARISON_BINARY_OPERATIONS:
+            return operand_sorts >= {_LoweredSort.BOOLEAN, _LoweredSort.NUMERIC}
+        return False
+    elif isinstance(expression, PiecewiseExpression):
+        branch_sorts = {
+            _classify_lowered_sort(branch, symbol_types)
+            for branch in (*expression.values, expression.otherwise)
+        }
+        return branch_sorts >= {_LoweredSort.BOOLEAN, _LoweredSort.NUMERIC}
+    return False
+
+
+def _find_bool_sort_hazard(
+    expression: Expression, symbol_types: Mapping[Identifier, SymbolType]
+) -> bool:
+    """Return whether any node of ``expression`` coerces a Boolean operand.
+
+    Screens the tree that is actually handed to the solver, so the check
+    covers every way a ``BoolVal`` can reach a numeric context: a ``bool``
+    set member, a ``bool`` literal written into an equation, and a
+    ``bool`` binding value substituted in before the check. The screen is
+    per-site: a Boolean literal consumed by a logical operation leaves the
+    rest of the tree decidable.
+
+    Args:
+        expression: Lowered conjunction, or the residual left after
+            substituting bindings into it.
+        symbol_types: Z3 sort for each free identifier of ``expression``.
+
+    Returns:
+        True if some node would lower through a Boolean-to-integer
+        coercion.
+
+    """
+    if _does_node_coerce_a_bool_operand(expression, symbol_types):
+        return True
+    return any(
+        _find_bool_sort_hazard(child, symbol_types)
+        for child in expression.get_visit_children()
+    )
+
+
 def _decide_satisfiability(
     expression: Expression,
     symbol_types: Mapping[Identifier, SymbolType],
@@ -972,12 +1189,30 @@ def _decide_satisfiability(
 ) -> ConstraintOutcome:
     """Classify satisfiability of ``expression`` via the solver seam.
 
+    Validates the caller's symbol types first, then screens the expression
+    for the Z3 Boolean-coercion hazard, and only then consults the solver.
+    The precondition therefore raises whether or not the expression is
+    hazardous, and a hazardous expression reports ``UNDECIDED`` instead of
+    a decided outcome the lowering cannot support.
+
+    Args:
+        expression: Expression to decide.
+        symbol_types: Z3 sort for each free identifier of ``expression``.
+        timeout_milliseconds: Optional bound, in milliseconds, on the
+            solver invocation.
+
+    Returns:
+        ``SATISFIED``/``VIOLATED`` when the solver decides,
+        ``UNDECIDED`` on a hazardous lowering or an inconclusive solver.
+
     Raises:
         MissingSymbolTypeError: If ``symbol_types`` lacks an entry for a
             free identifier of ``expression``.
 
     """
     _validate_symbol_types_cover_free_identifiers(expression, symbol_types)
+    if _find_bool_sort_hazard(expression, symbol_types):
+        return ConstraintOutcome.UNDECIDED
     satisfiable = check_expression_satisfiability(
         expression,
         dict(symbol_types),
@@ -990,78 +1225,140 @@ def _decide_satisfiability(
     return ConstraintOutcome.VIOLATED
 
 
-def _contains_bool_literal(expression: Expression) -> bool:
-    """Return whether ``expression``'s tree contains a `bool`-valued literal.
+def _build_literal_ordering_key(value: LiteralType) -> str:
+    """Return an ordering key constant on ``LiteralExpression`` equivalence.
 
-    Recurses via ``get_visit_children``, the same traversal
-    ``Expression.get_free_identifiers`` uses, so a nested
-    ``LiteralExpression`` is found regardless of depth. Checks
-    ``type(value) is bool`` rather than ``isinstance(value, bool)``,
-    matching ``LiteralExpression.__post_init__``'s own discrimination
-    between a ``bool`` value and a plain ``int`` value (``bool`` is an
-    ``int`` subclass).
+    ``LiteralExpression`` compares literals by bucket and canonical form
+    rather than by stored Python type, so the key has to collapse the same
+    forms: the integer-grammar strings ``"5"`` and ``"05"`` key alike with
+    the integer ``5``, the float-grammar strings ``"1.5"`` and ``"1.50"``
+    key alike as one exact decimal, and ``-0.0`` keys alike with ``0.0``.
+    A ``bool`` keys apart from every integer, and an exact-decimal string
+    apart from the binary ``float`` carrying the same digits.
+
+    Args:
+        value: Stored value of a ``LiteralExpression``.
+
+    Returns:
+        Bucket-prefixed textual key.
 
     """
-    if isinstance(expression, LiteralExpression) and type(expression.value) is bool:
-        return True
-    return any(
-        _contains_bool_literal(child) for child in expression.get_visit_children()
+    if isinstance(value, bool):
+        return f"bool:{value}"
+    elif isinstance(value, int):
+        return f"int:{value}"
+    elif isinstance(value, float):
+        # Adding zero maps -0.0 to 0.0; the two are equal and so must key alike.
+        return f"float-binary:{value + 0.0!r}"
+    # A string-form literal matches the integer grammar or the float grammar,
+    # and only the latter carries a decimal point.
+    elif "." in value:
+        return f"float-decimal:{Decimal(value).normalize()}"
+    return f"int:{int(value)}"
+
+
+def _build_member_ordering_key(value: Any) -> str:
+    """Return an ordering key constant on type-strict member equality.
+
+    Members compare by ``(type(value), value)``, so the key carries the
+    type name: the string ``"1"``, the integer ``1``, the float ``1.0``,
+    and ``True`` are four distinct members and get four distinct keys.
+    Containers recurse, and a ``frozenset``'s element keys are sorted so
+    the container key does not depend on iteration order. A
+    ``Serializable`` member keys on its serialized data, which is stable
+    across processes where its ``repr`` need not be.
+
+    Args:
+        value: Raw (unwrapped) constraint member.
+
+    Returns:
+        Type-tagged textual key.
+
+    """
+    if isinstance(value, tuple):
+        elements = ",".join(_build_member_ordering_key(item) for item in value)
+        return f"tuple({elements})"
+    elif isinstance(value, frozenset):
+        elements = ",".join(sorted(_build_member_ordering_key(item) for item in value))
+        return f"frozenset({elements})"
+    elif isinstance(value, (bool, int, float, str)):
+        return f"{type(value).__name__}:{value!r}"
+    qualified_name = f"{type(value).__module__}.{type(value).__qualname__}"
+    if isinstance(value, Serializable):
+        return f"{qualified_name}:{value.serialize_to_dict()!r}"
+    return f"{qualified_name}:{value!r}"
+
+
+def _build_expression_ordering_key(expression: Expression) -> str:
+    """Return an ordering key constant on expression structural equivalence.
+
+    Renders the tree as ``NodeType[node data](child keys)``. Node data is
+    whatever the node compares by beyond its children: a literal's bucket
+    and canonical form, an identifier's ``id``, an operation's name, or a
+    call's function name. A ``PiecewiseExpression`` needs none, since its
+    children already encode the cases and the fallback.
+
+    Args:
+        expression: Expression to key.
+
+    Returns:
+        Textual key for the whole subtree.
+
+    """
+    children = ",".join(
+        _build_expression_ordering_key(child)
+        for child in expression.get_visit_children()
     )
+    node_data = _render_expression_node_ordering_data(expression)
+    return f"{type(expression).__name__}[{node_data}]({children})"
 
 
-def _find_bool_member_type_ambiguity(
-    constraints: tuple[Constraint, ...],
-    symbol_types: Mapping[Identifier, SymbolType],
-) -> bool:
-    """Return whether a `bool` literal among ``constraints`` is sort-ambiguous.
+def _render_expression_node_ordering_data(expression: Expression) -> str:
+    """Return one node's own ordering data, excluding its children."""
+    if isinstance(expression, LiteralExpression):
+        return _build_literal_ordering_key(expression.value)
+    elif isinstance(expression, IdentifierExpression):
+        return f"id:{expression.identifier.id}"
+    elif isinstance(expression, (BinaryExpression, UnaryExpression)):
+        return expression.operation.value
+    elif isinstance(expression, CallExpression):
+        return f"call:{expression.function_name}"
+    return ""
 
-    Two constructs hit the same Z3 coercion hazard:
 
-    - A ``bool`` member of an ``InSetConstraint``/``NotInSetConstraint``
-      lowers to a Z3 ``BoolVal``.
-    - A ``bool``-valued ``LiteralExpression`` anywhere in an
-      ``EquationConstraint``'s expression tree also lowers to a Z3
-      ``BoolVal``.
+def _build_constraint_ordering_key(constraint: Constraint) -> str:
+    """Return the canonical sort key ``ConstraintSystem`` orders its members by.
 
-    Compared against an ``IntVal``/``RealVal`` (whether that literal comes
-    from a free variable or from a bound identifier substituted to a
-    concrete value), the Z3 Python bindings silently coerce the
-    ``BoolVal`` into an integer via an implicit ``If`` (``True`` becomes
-    ``1``, ``False`` becomes ``0``). This collapses the type-strict
-    distinction the constraint's own ``evaluate``/``evaluate_with_bindings``
-    preserve whenever the bound value happens to be ``0`` or ``1``, so this
-    check does not special-case already-bound identifiers: only a variable
-    whose ``symbol_types`` entry is confirmed ``SymbolType.BOOL`` is
-    exempt -- for an ``EquationConstraint``, every free identifier of its
-    *expression* (not necessarily including its declared ``variable``,
-    which ``convert_to_expression`` does not add back in when the
-    expression does not itself reference it) must be confirmed
-    ``SymbolType.BOOL``, since the bool literal's position within the
-    expression tree is not tracked.
+    The key is constant on structural-equivalence classes: two
+    structurally equivalent constraints always key alike, so a system's
+    member order does not depend on construction order. It is keyed on
+    the same things equivalence compares -- the concrete kind, the
+    variable's ``Identifier.id``, and either the expression tree or the
+    type-strict member set -- rather than on ``repr``, which neither
+    separates every distinct constraint nor agrees on every equivalent
+    pair.
 
-    This is deliberately conservative: an ``EquationConstraint`` can hold a
-    ``bool`` literal that is never actually compared against a non-bool
-    identifier, in which case this still reports ambiguity. Over-triggering
-    only costs a spurious ``UNDECIDED``; the alternative -- a provably
-    wrong decided outcome -- is not acceptable.
+    A ``Constraint`` subclass declared outside this module falls back to
+    its ``repr``, which the subclassing contract requires to identify the
+    kind and the variable.
+
+    Args:
+        constraint: Member to key.
+
+    Returns:
+        Textual key ordering the member within its system.
 
     """
-    for constraint in constraints:
-        if isinstance(constraint, (InSetConstraint, NotInSetConstraint)):
-            if symbol_types.get(constraint.variable) is SymbolType.BOOL:
-                continue
-            if any(isinstance(member, bool) for member in constraint.members):
-                return True
-        elif isinstance(constraint, EquationConstraint):
-            if not _contains_bool_literal(constraint.expression):
-                continue
-            if all(
-                symbol_types.get(identifier) is SymbolType.BOOL
-                for identifier in constraint.expression.get_free_identifiers()
-            ):
-                continue
-            return True
-    return False
+    kind = type(constraint).__name__
+    if isinstance(constraint, EquationConstraint):
+        expression_key = _build_expression_ordering_key(constraint.expression)
+        return f"{kind}|{constraint.variable.id}|{expression_key}"
+    elif isinstance(constraint, (InSetConstraint, NotInSetConstraint)):
+        members = ",".join(
+            sorted(_build_member_ordering_key(member) for member in constraint.members)
+        )
+        return f"{kind}|{constraint.variable.id}|{{{members}}}"
+    return f"{kind}|{constraint!r}"
 
 
 def create_constraint_system(*constraints: Constraint) -> "ConstraintSystem":
@@ -1073,7 +1370,7 @@ def create_constraint_system(*constraints: Constraint) -> "ConstraintSystem":
 
     Returns:
         A frozen ``ConstraintSystem`` holding the constraints in canonical
-        (repr-sorted) order.
+        order.
 
     Raises:
         ConstraintError: If any argument is not a ``Constraint``.
@@ -1087,8 +1384,11 @@ def create_constraint_system(*constraints: Constraint) -> "ConstraintSystem":
 class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenceMixin):
     """An ordered conjunction of constraints over shared identifiers.
 
-    Semantically the logical AND of its member constraints. Constraints
-    are normalized into canonical (repr-sorted) order at construction, so
+    Semantically the logical AND of its member constraints. The
+    ``constraints`` argument is materialized once before it is traversed,
+    so a single-pass iterable is retained in full rather than consumed
+    into an empty system. Constraints are then normalized into canonical
+    order, keyed on the same things structural equivalence compares, so
     structurally equivalent systems built from differently ordered inputs
     are structurally equivalent and serialize identically. Duplicate
     constraints are retained (conjunction is idempotent). Instances are
@@ -1107,7 +1407,11 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
     constraints: tuple[Constraint, ...]
 
     def __post_init__(self) -> None:
-        for constraint in self.constraints:
+        # Materialize before anything else: validation and canonical ordering
+        # each traverse the members, and a one-shot iterator would be empty by
+        # the second pass.
+        constraints = tuple(self.constraints)
+        for constraint in constraints:
             if not isinstance(constraint, Constraint):
                 raise ConstraintError(
                     "ConstraintSystem members must be Constraint instances, "
@@ -1115,7 +1419,9 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
                     f"{type(constraint).__name__}."
                 )
         object.__setattr__(
-            self, "constraints", tuple(sorted(self.constraints, key=repr))
+            self,
+            "constraints",
+            tuple(sorted(constraints, key=_build_constraint_ordering_key)),
         )
 
     def get_free_identifiers(self) -> frozenset[Identifier]:
@@ -1188,17 +1494,20 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
         The empty system returns ``SATISFIED`` without invoking the
         solver.
 
-        Limitation: a ``bool`` member of an ``InSetConstraint`` or
-        ``NotInSetConstraint`` whose variable's sort is not
-        ``SymbolType.BOOL``, or a ``bool``-valued literal anywhere in an
-        ``EquationConstraint``'s expression whose free identifiers are not
-        all ``SymbolType.BOOL``, cannot be lowered soundly through the
-        current Z3 bridge -- the Z3 Python bindings coerce a ``BoolVal``
-        compared against a non-bool sort into an integer (``True`` becomes
-        ``1``), collapsing the package's type-strict membership (and, for
-        an equation, literal-comparison) semantics. This method detects
-        both cases and returns ``UNDECIDED`` rather than a provably-wrong
-        decided outcome.
+        Limitation: the lowered conjunction is screened for the Z3
+        Boolean-coercion hazard before the solver is consulted, and a
+        hazardous conjunction returns ``UNDECIDED`` rather than a
+        provably-wrong decided outcome. The hazard is a ``BoolVal``
+        reaching a numeric context -- an arithmetic operand, one side of a
+        comparison whose other side is numeric, or a piecewise branch
+        facing a numeric sibling -- where the Z3 Python bindings silently
+        rewrite it to ``If(b, 1, 0)`` and collapse this package's
+        type-strict semantics. That covers a ``bool`` set member, a
+        ``bool`` literal written into an equation, and a
+        ``SymbolType.BOOL`` variable compared against a numeric literal.
+        The screen is per-site: a ``bool`` literal consumed by
+        ``logical_and``/``logical_or``/``logical_not``, or standing alone
+        as the whole expression, lowers faithfully and stays decidable.
 
         Args:
             symbol_types: Z3 sort for each free identifier of the system.
@@ -1208,8 +1517,11 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
 
         Raises:
             MissingSymbolTypeError: If ``symbol_types`` lacks an entry for
-                a free identifier of the lowered conjunction. This is a
-                raise, not the ``ConstraintOutcome.UNDECIDED`` degradation
+                a free identifier of the lowered conjunction. Checked
+                ahead of the hazard screen, so the precondition raises
+                even for a conjunction that would otherwise be reported
+                ``UNDECIDED``. This is a raise, not the
+                ``ConstraintOutcome.UNDECIDED`` degradation
                 ``evaluate_with_bindings`` uses for a missing *value*
                 binding: a missing symbol type is a caller precondition
                 violation the Z3 bridge cannot proceed without, while a
@@ -1223,8 +1535,6 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
         """
         if not self.constraints:
             return ConstraintOutcome.SATISFIED
-        if _find_bool_member_type_ambiguity(self.constraints, symbol_types):
-            return ConstraintOutcome.UNDECIDED
         return _decide_satisfiability(
             self.convert_to_expression(),
             symbol_types,
@@ -1246,14 +1556,13 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
         identifiers left free after substitution. Answers questions of the
         form "given x = 4, can y and z still be chosen?".
 
-        Limitation: the same ``bool`` sort ambiguity documented on
-        ``check_satisfiability`` applies here, covering both the
-        set-membership case and the equation-constraint bool-literal case:
-        a system with a ``bool`` set member, or an ``EquationConstraint``
-        with a ``bool``-valued literal, whose relevant identifier(s) are
-        not confirmed ``SymbolType.BOOL`` returns ``UNDECIDED``, even when
-        ``bindings`` assigns those variables concrete values (Z3's sort
-        coercion can still misclassify a bound value of ``0`` or ``1``).
+        Limitation: the same Boolean-coercion hazard documented on
+        ``check_satisfiability`` applies here, screened against the
+        residual rather than the original conjunction. Substitution is
+        therefore part of the screen: a ``bool`` binding value lands in
+        the residual exactly as a ``bool`` set member does and is screened
+        the same way, while binding a variable to a value of the matching
+        sort can retire a hazard the unsubstituted conjunction had.
 
         Args:
             bindings: Partial assignment substituted into the conjunction
@@ -1267,11 +1576,13 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
         Raises:
             MissingSymbolTypeError: If ``symbol_types`` lacks an entry for
                 a free identifier of the residual expression left after
-                substitution. Contrast a missing entry in ``bindings``
-                itself: an identifier ``bindings`` does not cover is left
-                free in the residual rather than raising, so it only
-                raises here if ``symbol_types`` also fails to cover it. A
-                missing *value* binding degrades to
+                substitution. Checked ahead of the hazard screen, so the
+                precondition raises even for a residual that would
+                otherwise be reported ``UNDECIDED``. Contrast a missing
+                entry in ``bindings`` itself: an identifier ``bindings``
+                does not cover is left free in the residual rather than
+                raising, so it only raises here if ``symbol_types`` also
+                fails to cover it. A missing *value* binding degrades to
                 ``ConstraintOutcome.UNDECIDED`` on ``evaluate_with_bindings``;
                 a missing symbol type here always raises, since the Z3
                 bridge cannot proceed without a sort for every free
@@ -1282,8 +1593,6 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
         """
         if not self.constraints:
             return ConstraintOutcome.SATISFIED
-        if _find_bool_member_type_ambiguity(self.constraints, symbol_types):
-            return ConstraintOutcome.UNDECIDED
         environment = _coerce_bindings_to_environment(bindings)
         residual = self.convert_to_expression().substitute(environment)
         return _decide_satisfiability(

--- a/src/fhy_core/symbolic/constraint.py
+++ b/src/fhy_core/symbolic/constraint.py
@@ -66,6 +66,7 @@ from collections.abc import Collection, Hashable, Iterator, Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import Enum, auto
+from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -117,7 +118,11 @@ from .expression import (
     make_binary_expression,
     pformat_expression,
 )
-from .solver import check_expression_satisfiability, simplify_expression
+from .solver import (
+    check_expression_satisfiability,
+    simplify_expression,
+    validate_timeout_milliseconds,
+)
 from .symbol_type import SymbolType
 
 _LOGGER = get_logger(__name__)
@@ -572,6 +577,19 @@ class Constraint(
         are ignored. ``EquationConstraint`` overrides this to substitute
         every bound identifier simultaneously.
 
+        A non-literal ``Expression`` binding is a structural limitation of
+        the leaves that use this implementation, not a per-call outcome:
+        ``InSetConstraint`` and ``NotInSetConstraint`` decide membership
+        against a concrete value, so no symbolic expression is decidable
+        against them and supplying a different one will not help. That
+        makes ``ConstraintBindings`` wider than these leaves consume --
+        only ``EquationConstraint``, which substitutes into an expression,
+        uses the full range. Both this case and a missing binding are
+        logged at ``DEBUG`` through the module logger, naming the
+        identifier responsible, since a set constraint's ``evaluate``
+        never reports ``UNDECIDED`` and so gives no other clue which of
+        the two occurred.
+
         Args:
             bindings: Mapping from identifiers to candidate values. Raw
                 ``LiteralType`` values and ``Expression`` values are both
@@ -590,10 +608,26 @@ class Constraint(
         """
         snapshot = dict(bindings)
         if self.variable not in snapshot:
+            _LOGGER.debug(
+                "%s.evaluate_with_bindings: no binding for variable %r; the "
+                "bindings supplied %s; reporting UNDECIDED",
+                type(self).__name__,
+                self.variable,
+                format_comma_separated_list(tuple(snapshot)) or "no identifiers",
+            )
             return ConstraintOutcome.UNDECIDED
         value = snapshot[self.variable]
         if isinstance(value, Expression):
             if not isinstance(value, LiteralExpression):
+                _LOGGER.debug(
+                    "%s.evaluate_with_bindings: the binding for %r is the "
+                    "non-literal expression %r; this leaf decides against a "
+                    "concrete value and cannot consume a symbolic one; "
+                    "reporting UNDECIDED",
+                    type(self).__name__,
+                    self.variable,
+                    value,
+                )
                 return ConstraintOutcome.UNDECIDED
             value = value.value
         return self.evaluate(value)
@@ -820,15 +854,27 @@ class InSetConstraint(Constraint):
             "valid_values",
             tuple(_unwrap_member(member) for member in wrapped),
         )
+        # Seed the ``_members`` cache with the set this normalization pass has
+        # already built, so no reader has to derive it a second time.
+        object.__setattr__(self, "_members", wrapped)
 
     @property
     def members(self) -> tuple[ConstraintMember, ...]:
         """Return the permitted members as raw values, in no particular order."""
         return tuple(self.valid_values)
 
-    @property
+    @cached_property
     def _members(self) -> frozenset[_TypedMember]:
-        """Return the type-strict member set, re-derived from the raw view."""
+        """Return the type-strict member set membership is decided against.
+
+        Held as a stored set rather than re-derived per read: ``evaluate``
+        is then a constant-time frozenset lookup, and ``__repr__`` -- which
+        feeds the ``ConstraintSystem`` ordering key -- costs no wrapper
+        allocations. ``__post_init__`` seeds it with the set built during
+        normalization; this body re-derives it from ``valid_values`` for an
+        instance that reaches a reader unseeded, so the public field stays
+        the single source of truth.
+        """
         return _wrap_member_collection(self.valid_values)
 
     @classmethod
@@ -915,15 +961,27 @@ class NotInSetConstraint(Constraint):
             "invalid_values",
             tuple(_unwrap_member(member) for member in wrapped),
         )
+        # Seed the ``_members`` cache with the set this normalization pass has
+        # already built, so no reader has to derive it a second time.
+        object.__setattr__(self, "_members", wrapped)
 
     @property
     def members(self) -> tuple[ConstraintMember, ...]:
         """Return the forbidden members as raw values, in no particular order."""
         return tuple(self.invalid_values)
 
-    @property
+    @cached_property
     def _members(self) -> frozenset[_TypedMember]:
-        """Return the type-strict member set, re-derived from the raw view."""
+        """Return the type-strict member set membership is decided against.
+
+        Held as a stored set rather than re-derived per read: ``evaluate``
+        is then a constant-time frozenset lookup, and ``__repr__`` -- which
+        feeds the ``ConstraintSystem`` ordering key -- costs no wrapper
+        allocations. ``__post_init__`` seeds it with the set built during
+        normalization; this body re-derives it from ``invalid_values`` for
+        an instance that reaches a reader unseeded, so the public field
+        stays the single source of truth.
+        """
         return _wrap_member_collection(self.invalid_values)
 
     @classmethod
@@ -1153,8 +1211,8 @@ def _does_node_coerce_a_bool_operand(
 
 def _find_bool_sort_hazard(
     expression: Expression, symbol_types: Mapping[Identifier, SymbolType]
-) -> bool:
-    """Return whether any node of ``expression`` coerces a Boolean operand.
+) -> Expression | None:
+    """Return the first node of ``expression`` that coerces a Boolean operand.
 
     Screens the tree that is actually handed to the solver, so the check
     covers every way a ``BoolVal`` can reach a numeric context: a ``bool``
@@ -1169,22 +1227,54 @@ def _find_bool_sort_hazard(
         symbol_types: Z3 sort for each free identifier of ``expression``.
 
     Returns:
-        True if some node would lower through a Boolean-to-integer
-        coercion.
+        The offending node, or ``None`` when every node lowers faithfully.
+        The node is returned rather than a flag so the caller can name the
+        site it refused to lower.
 
     """
     if _does_node_coerce_a_bool_operand(expression, symbol_types):
-        return True
-    return any(
-        _find_bool_sort_hazard(child, symbol_types)
-        for child in expression.get_visit_children()
+        return expression
+    for child in expression.get_visit_children():
+        hazard = _find_bool_sort_hazard(child, symbol_types)
+        if hazard is not None:
+            return hazard
+    return None
+
+
+def _render_identifier_sorts(
+    expression: Expression, symbol_types: Mapping[Identifier, SymbolType]
+) -> str:
+    """Return each free identifier of ``expression`` paired with its declared sort.
+
+    Args:
+        expression: Node whose free identifiers are described.
+        symbol_types: Z3 sort for each free identifier.
+
+    Returns:
+        A comma-separated ``identifier: SORT`` listing, ordered by
+        identifier id; ``"none"`` when the node has no free identifier,
+        and ``"unknown"`` in place of a sort ``symbol_types`` does not
+        carry.
+
+    """
+    identifiers = sorted(
+        expression.get_free_identifiers(), key=lambda identifier: identifier.id
     )
+    if not identifiers:
+        return "none"
+    rendered: list[str] = []
+    for identifier in identifiers:
+        symbol_type = symbol_types.get(identifier)
+        sort_name = "unknown" if symbol_type is None else symbol_type.name
+        rendered.append(f"{identifier!r}: {sort_name}")
+    return format_comma_separated_list(rendered)
 
 
 def _decide_satisfiability(
     expression: Expression,
     symbol_types: Mapping[Identifier, SymbolType],
     *,
+    context: str,
     timeout_milliseconds: int | None = None,
 ) -> ConstraintOutcome:
     """Classify satisfiability of ``expression`` via the solver seam.
@@ -1193,11 +1283,17 @@ def _decide_satisfiability(
     for the Z3 Boolean-coercion hazard, and only then consults the solver.
     The precondition therefore raises whether or not the expression is
     hazardous, and a hazardous expression reports ``UNDECIDED`` instead of
-    a decided outcome the lowering cannot support.
+    a decided outcome the lowering cannot support. A hazard is logged at
+    ``WARNING`` through the module logger: it is a gap in what the Z3
+    bridge can express, not the routine partial evaluation that
+    ``evaluate_with_bindings`` reports at ``DEBUG``, and no solver setting
+    the caller can reach will turn it into a decided answer.
 
     Args:
         expression: Expression to decide.
         symbol_types: Z3 sort for each free identifier of ``expression``.
+        context: Public method name the outcome is reported under, used to
+            attribute the warning.
         timeout_milliseconds: Optional bound, in milliseconds, on the
             solver invocation.
 
@@ -1211,7 +1307,19 @@ def _decide_satisfiability(
 
     """
     _validate_symbol_types_cover_free_identifiers(expression, symbol_types)
-    if _find_bool_sort_hazard(expression, symbol_types):
+    hazard = _find_bool_sort_hazard(expression, symbol_types)
+    if hazard is not None:
+        _LOGGER.warning(
+            "%s: node %r lowers a Boolean operand into a numeric context, where "
+            "the Z3 bindings rewrite it to If(b, 1, 0) and collapse this "
+            "package's type-strict semantics; identifier sorts at that node: "
+            "%s. The expression is not handed to the solver and the check "
+            "reports UNDECIDED; bounding timeout_milliseconds cannot change "
+            "this outcome.",
+            context,
+            hazard,
+            _render_identifier_sorts(hazard, symbol_types),
+        )
         return ConstraintOutcome.UNDECIDED
     satisfiable = check_expression_satisfiability(
         expression,
@@ -1437,8 +1545,10 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
         ``VIOLATED`` if any member is ``VIOLATED`` (a definite violation
         dominates indeterminacy; members are checked in canonical order and
         checking stops at the first violation); ``SATISFIED`` if every
-        member is ``SATISFIED``; ``UNDECIDED`` otherwise. The empty system
-        is vacuously ``SATISFIED``.
+        member is ``SATISFIED``; ``UNDECIDED`` otherwise. Each undecided
+        member is logged at ``DEBUG`` through the module logger, so a
+        system-level ``UNDECIDED`` identifies the members it came from
+        rather than leaving the caller to re-check each one by hand.
 
         """
         resolved_bindings = dict(bindings)
@@ -1448,6 +1558,12 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
             if outcome is ConstraintOutcome.VIOLATED:
                 return ConstraintOutcome.VIOLATED
             if outcome is ConstraintOutcome.UNDECIDED:
+                _LOGGER.debug(
+                    "ConstraintSystem.evaluate_with_bindings: member %r is "
+                    "undecided under the given bindings; the conjunction "
+                    "reports UNDECIDED unless a later member is violated",
+                    constraint,
+                )
                 saw_undecided = True
         return (
             ConstraintOutcome.UNDECIDED
@@ -1530,14 +1646,18 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
             ConstraintError: If a member cannot be converted to an
                 expression.
             ValueError: If ``timeout_milliseconds`` is not None and not
-                positive.
+                positive. Checked before the empty-system and hazard
+                early returns, so an inadmissible bound is rejected even
+                when the outcome is decided without the solver.
 
         """
+        validate_timeout_milliseconds(timeout_milliseconds)
         if not self.constraints:
             return ConstraintOutcome.SATISFIED
         return _decide_satisfiability(
             self.convert_to_expression(),
             symbol_types,
+            context="ConstraintSystem.check_satisfiability",
             timeout_milliseconds=timeout_milliseconds,
         )
 
@@ -1588,15 +1708,21 @@ class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenc
                 bridge cannot proceed without a sort for every free
                 identifier.
             ValueError: If ``timeout_milliseconds`` is not None and not
-                positive.
+                positive. Checked before the empty-system and hazard
+                early returns, so an inadmissible bound is rejected even
+                when the outcome is decided without the solver.
 
         """
+        validate_timeout_milliseconds(timeout_milliseconds)
         if not self.constraints:
             return ConstraintOutcome.SATISFIED
         environment = _coerce_bindings_to_environment(bindings)
         residual = self.convert_to_expression().substitute(environment)
         return _decide_satisfiability(
-            residual, symbol_types, timeout_milliseconds=timeout_milliseconds
+            residual,
+            symbol_types,
+            context="ConstraintSystem.check_satisfiability_with_bindings",
+            timeout_milliseconds=timeout_milliseconds,
         )
 
     @classmethod

--- a/src/fhy_core/symbolic/constraint.py
+++ b/src/fhy_core/symbolic/constraint.py
@@ -375,6 +375,30 @@ def _wrap_member_collection(
     return frozenset(_wrap_member(value) for value in values)
 
 
+def _order_members_canonically(
+    members: Collection[ConstraintMember],
+) -> tuple[ConstraintMember, ...]:
+    """Order raw members the same way in every process.
+
+    Normalization stores its result in ``frozenset`` iteration order,
+    which is hash-table slot order and therefore depends on the
+    per-process hash seed for ``str`` members. Ordering by
+    ``_build_member_ordering_key`` gives the accessor a sequence a caller
+    can iterate for reproducible output, and keeps type-strict members
+    apart, since the key is type-tagged and resolves a ``Serializable``
+    member through its serialized form rather than its address-based
+    ``repr``.
+
+    Args:
+        members: Raw members held by a set constraint.
+
+    Returns:
+        The same members in canonical order.
+
+    """
+    return tuple(sorted(members, key=_build_member_ordering_key))
+
+
 def _lift_member_to_literal_expression(value: ConstraintMember) -> LiteralExpression:
     """Lift a constraint member to a ``LiteralExpression``.
 
@@ -860,8 +884,14 @@ class InSetConstraint(Constraint):
 
     @property
     def members(self) -> tuple[ConstraintMember, ...]:
-        """Return the permitted members as raw values, in no particular order."""
-        return tuple(self.valid_values)
+        """Return the permitted members as raw values, in canonical order.
+
+        Ordering is reproducible across processes, so a caller may iterate
+        this to produce deterministic output. The ``valid_values`` field
+        holds the same members in an unspecified order.
+
+        """
+        return _order_members_canonically(self.valid_values)
 
     @cached_property
     def _members(self) -> frozenset[_TypedMember]:
@@ -967,8 +997,14 @@ class NotInSetConstraint(Constraint):
 
     @property
     def members(self) -> tuple[ConstraintMember, ...]:
-        """Return the forbidden members as raw values, in no particular order."""
-        return tuple(self.invalid_values)
+        """Return the forbidden members as raw values, in canonical order.
+
+        Ordering is reproducible across processes, so a caller may iterate
+        this to produce deterministic output. The ``invalid_values`` field
+        holds the same members in an unspecified order.
+
+        """
+        return _order_members_canonically(self.invalid_values)
 
     @cached_property
     def _members(self) -> frozenset[_TypedMember]:

--- a/src/fhy_core/symbolic/constraint.py
+++ b/src/fhy_core/symbolic/constraint.py
@@ -30,22 +30,39 @@ private; the public API accepts and returns raw values.
 Set-constraint serialization is deterministic: members are emitted in
 ``repr``-sorted order, and the corresponding ``convert_to_expression``
 leaves are emitted in the same order.
+
+Every constraint additionally supports a *bindings* evaluation API --
+``evaluate_with_bindings`` / ``is_satisfied_with_bindings`` -- that checks
+the constraint against a ``Mapping[Identifier, value]`` instead of a single
+positional value. This makes multi-variable (dependent) constraints
+usable: an ``EquationConstraint`` whose expression mentions identifiers
+beyond ``self.variable`` is decided once every identifier it references
+is bound. ``ConstraintSystem`` is the companion set-level value object: a
+canonically ordered conjunction of constraints, possibly spanning several
+variables, with joint-satisfiability checking backed by
+``fhy_core.symbolic.solver.check_expression_satisfiability``. It is not a
+``Constraint`` subclass -- joint satisfiability is a property of a
+collection, not of any single predicate.
 """
 
 from fhy_core.utils.override import override
 
 __all__ = [
     "Constraint",
+    "ConstraintBindings",
     "ConstraintError",
     "ConstraintMember",
     "ConstraintOutcome",
+    "ConstraintSystem",
     "EquationConstraint",
     "InSetConstraint",
+    "MissingSymbolTypeError",
     "NotInSetConstraint",
+    "create_constraint_system",
 ]
 
 from abc import ABC, abstractmethod
-from collections.abc import Collection, Hashable, Iterator
+from collections.abc import Collection, Hashable, Iterator, Mapping
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from typing import (
@@ -56,11 +73,11 @@ from typing import (
     TypedDict,
     TypeGuard,
     TypeVar,
-    cast,
     runtime_checkable,
 )
 
 from fhy_core.error import register_error
+from fhy_core.identifier import Identifier
 from fhy_core.logger import get_logger
 from fhy_core.serialization import (
     DeserializationDictStructureError,
@@ -85,7 +102,6 @@ from fhy_core.term import (
 from fhy_core.traits import FrozenMixin
 from fhy_core.utils import format_comma_separated_list
 
-from ..identifier import Identifier
 from .expression import (
     BinaryOperation,
     Expression,
@@ -94,14 +110,50 @@ from .expression import (
     make_binary_expression,
     pformat_expression,
 )
-from .solver import simplify_expression
+from .solver import check_expression_satisfiability, simplify_expression
+from .symbol_type import SymbolType
 
 _LOGGER = get_logger(__name__)
+
+ConstraintBindings: TypeAlias = Mapping[Identifier, "Expression | LiteralType"]
+"""Assignment of candidate values (literals or expressions) to identifiers."""
+
+
+def _coerce_bindings_to_environment(
+    bindings: ConstraintBindings,
+) -> dict[Identifier, Expression]:
+    """Coerce every raw ``LiteralType`` binding value to a ``LiteralExpression``.
+
+    ``Expression`` values (including a non-literal, symbolic ``Expression``)
+    pass through unchanged.
+    """
+    return {
+        identifier: (
+            LiteralExpression(value)
+            if isinstance(value, (str, float, int, bool))
+            else value
+        )
+        for identifier, value in bindings.items()
+    }
 
 
 @register_error
 class ConstraintError(ValueError):
     """Domain error for constraint construction, validation, and conversion."""
+
+
+@register_error
+class MissingSymbolTypeError(ValueError):
+    """Raised when ``symbol_types`` lacks an entry for a free identifier being lowered.
+
+    ``ConstraintSystem.check_satisfiability`` and
+    ``check_satisfiability_with_bindings`` require a Z3 sort for every free
+    identifier of the expression they lower. A missing entry is a caller
+    precondition violation, not a dictionary lookup miss, so this is a
+    ``ValueError`` rather than a ``KeyError``: the missing-identifier
+    message must render cleanly in a traceback, and a bare ``except
+    KeyError`` elsewhere in a caller's code must not silently swallow it.
+    """
 
 
 class ConstraintOutcome(Enum):
@@ -150,8 +202,8 @@ class MemberCollection(Protocol[_MemberT_co]):
     A structural, immutable-by-contract collection: any ``set``, ``list``,
     ``tuple``, or ``frozenset`` of members satisfies it. Used as the
     constructor-input type for the set constraints so callers can pass any of
-    those literals while the stored field is a normalized
-    ``frozenset[_TypedMember]``. The collection is only iterated during
+    those literals while the stored field is normalized to a deduplicated
+    tuple of raw values. The collection is only iterated during
     construction; the constraint never mutates or retains the caller's
     collection.
     """
@@ -297,6 +349,20 @@ def _normalize_constraint_member_collection(
     return frozenset(wrapped_values)
 
 
+def _wrap_member_collection(
+    values: Collection[ConstraintMember],
+) -> frozenset[_TypedMember]:
+    """Wrap an already-validated raw member collection for type-strict comparison.
+
+    Unlike ``_normalize_constraint_member_collection``, this performs no
+    validation or hashability check: it re-derives the type-strict view of
+    a collection that has already passed through construction once (the
+    post-``__post_init__`` ``valid_values``/``invalid_values`` field).
+
+    """
+    return frozenset(_wrap_member(value) for value in values)
+
+
 def _lift_member_to_literal_expression(value: ConstraintMember) -> LiteralExpression:
     """Lift a constraint member to a ``LiteralExpression``.
 
@@ -351,10 +417,10 @@ class _MemberSetData(TypedDict):
     members: list[SerializedDict]
 
 
-def _encode_member_set(members: frozenset[_TypedMember]) -> SerializedValue:
-    """Encode a wrapped-member set as a ``repr``-sorted list of wrapped dicts."""
+def _encode_member_set(members: Collection[ConstraintMember]) -> SerializedValue:
+    """Encode a raw member collection as a ``repr``-sorted list of wrapped dicts."""
     return sorted(
-        [_serialize_constraint_member(_unwrap_member(member)) for member in members],
+        [_serialize_constraint_member(member) for member in members],
         key=repr,
     )
 
@@ -473,6 +539,68 @@ class Constraint(
         """
         return self.evaluate(value) is ConstraintOutcome.SATISFIED
 
+    def get_free_identifiers(self) -> frozenset[Identifier]:
+        """Return every identifier this constraint constrains or references.
+
+        The base implementation returns ``frozenset((self.variable,))``.
+        ``EquationConstraint`` overrides it to also include the free
+        identifiers of its expression.
+
+        Returns:
+            Non-empty frozen set of identifiers; always contains
+            ``self.variable``.
+
+        """
+        return frozenset((self.variable,))
+
+    def evaluate_with_bindings(self, bindings: ConstraintBindings) -> ConstraintOutcome:
+        """Return the tri-state outcome of checking the constraint under bindings.
+
+        The base implementation is sound for any single-variable leaf: it
+        looks up ``self.variable`` in ``bindings``, unwraps a
+        ``LiteralExpression`` binding to its raw value, and delegates to
+        ``evaluate``. A missing binding for ``self.variable`` or a
+        non-literal ``Expression`` binding yields ``UNDECIDED``.
+        Identifiers in ``bindings`` that the constraint does not reference
+        are ignored. ``EquationConstraint`` overrides this to substitute
+        every bound identifier simultaneously.
+
+        Args:
+            bindings: Mapping from identifiers to candidate values. Raw
+                ``LiteralType`` values and ``Expression`` values are both
+                accepted; raw values behave identically to their
+                ``LiteralExpression`` wrapping.
+
+        Returns:
+            ``SATISFIED``/``VIOLATED`` when decidable under the given
+            (possibly partial) bindings; ``UNDECIDED`` otherwise.
+
+        Raises:
+            TypeError: Propagated from ``evaluate`` for leaves that reject
+                the bound value's type (e.g. an unhashable value against a
+                set constraint).
+
+        """
+        snapshot = dict(bindings)
+        if self.variable not in snapshot:
+            return ConstraintOutcome.UNDECIDED
+        value = snapshot[self.variable]
+        if isinstance(value, Expression):
+            if not isinstance(value, LiteralExpression):
+                return ConstraintOutcome.UNDECIDED
+            value = value.value
+        return self.evaluate(value)
+
+    def is_satisfied_with_bindings(self, bindings: ConstraintBindings) -> bool:
+        """Return whether the bindings provably satisfy the constraint.
+
+        Derived from ``evaluate_with_bindings``; both ``VIOLATED`` and
+        ``UNDECIDED`` map to ``False`` (conservative rejection), matching
+        ``is_satisfied``.
+
+        """
+        return self.evaluate_with_bindings(bindings) is ConstraintOutcome.SATISFIED
+
     @abstractmethod
     def convert_to_expression(self) -> Expression:
         """Return an expression equivalent to the constraint.
@@ -549,6 +677,54 @@ class EquationConstraint(Constraint):
         return ConstraintOutcome.UNDECIDED
 
     @override
+    def get_free_identifiers(self) -> frozenset[Identifier]:
+        """Return the expression's free identifiers united with ``variable``."""
+        return self.expression.get_free_identifiers() | {self.variable}
+
+    @override
+    def evaluate_with_bindings(self, bindings: ConstraintBindings) -> ConstraintOutcome:
+        """Substitute every bound identifier, simplify, and classify.
+
+        Coerces each raw ``LiteralType`` binding value to a
+        ``LiteralExpression`` (as ``evaluate`` does), substitutes the full
+        multi-key environment through ``simplify_expression``, and reports
+        ``SATISFIED`` for the ``bool`` literal ``True``, ``VIOLATED`` for
+        any other literal, and ``UNDECIDED`` when no literal results. The
+        designated ``variable`` has no special role here; it is bound like
+        any other free identifier. Logging on ``UNDECIDED``: DEBUG when
+        the residual (substituted and simplified) expression still has
+        free identifiers (expected partial evaluation, including the
+        case where a symbolic binding introduces a new free identifier),
+        WARNING when the residual has none -- every free identifier was
+        bound yet the simplifier still failed to reduce it to a literal
+        (matches ``evaluate``'s anomaly contract).
+
+        """
+        environment = _coerce_bindings_to_environment(bindings)
+        result = simplify_expression(self.expression, environment)
+        if isinstance(result, LiteralExpression):
+            if isinstance(result.value, bool) and result.value:
+                return ConstraintOutcome.SATISFIED
+            return ConstraintOutcome.VIOLATED
+        if result.get_free_identifiers():
+            _LOGGER.debug(
+                "%s.evaluate_with_bindings: substituted expression %r did not "
+                "reduce to a literal; free identifiers remain unbound; "
+                "reporting UNDECIDED",
+                type(self).__name__,
+                result,
+            )
+        else:
+            _LOGGER.warning(
+                "%s.evaluate_with_bindings: substituted expression %r did not "
+                "reduce to a literal though every free identifier was bound; "
+                "reporting UNDECIDED",
+                type(self).__name__,
+                result,
+            )
+        return ConstraintOutcome.UNDECIDED
+
+    @override
     def convert_to_expression(self) -> Expression:
         return self.expression
 
@@ -584,8 +760,9 @@ class InSetConstraint(Constraint):
     constraint's value set and ``VIOLATED`` otherwise, comparing by
     type-strict equality (so ``True`` and ``1`` are distinct members,
     and ``1`` and ``1.0`` are distinct members, including inside nested
-    ``tuple`` or ``frozenset`` members). Membership is always decidable,
-    so this constraint never reports ``UNDECIDED``.
+    ``tuple`` or ``frozenset`` members). A membership check against a
+    concrete value is always decidable, so ``evaluate`` never reports
+    ``UNDECIDED``.
 
     Determinism:
         ``convert_to_expression`` emits its leaves in ``repr``-sorted
@@ -597,36 +774,36 @@ class InSetConstraint(Constraint):
 
     variable: Identifier = field(metadata=compared_as_reference())
     # Declared as the constructor-input type. ``__post_init__`` normalizes this
-    # in place to a ``frozenset[_TypedMember]``; read the members through the
-    # ``members`` property (raw values) or ``_members`` (internal wrappers)
-    # rather than this field directly.
+    # in place to a deduplicated tuple of raw, unwrapped values (the same
+    # content the ``members`` property exposes) so no public attribute ever
+    # yields the internal ``_TypedMember`` wrapper. Comparison uses
+    # ``compared_as_value(key=_wrap_member_collection)`` rather than the
+    # default ``==`` so structural/alpha equivalence stays type-strict and
+    # order-independent despite the field itself being a plain tuple.
     valid_values: MemberCollection[ConstraintMember] = field(
         metadata={
-            **compared_as_value(),
+            **compared_as_value(key=_wrap_member_collection),
             "serialize_codec": _VALID_VALUES_CODEC,
         },
     )
 
     def __post_init__(self) -> None:
+        wrapped = _normalize_constraint_member_collection(self.valid_values)
         object.__setattr__(
             self,
             "valid_values",
-            _normalize_constraint_member_collection(self.valid_values),
+            tuple(_unwrap_member(member) for member in wrapped),
         )
 
     @property
     def members(self) -> tuple[ConstraintMember, ...]:
-        """Return the permitted members as raw values.
-
-        The ``valid_values`` field stores internal type-strict wrappers; this
-        accessor returns the unwrapped members in no particular order.
-        """
-        return tuple(_unwrap_member(member) for member in self._members)
+        """Return the permitted members as raw values, in no particular order."""
+        return tuple(self.valid_values)
 
     @property
     def _members(self) -> frozenset[_TypedMember]:
-        """Return the normalized, type-strict member set stored after init."""
-        return cast(frozenset[_TypedMember], self.valid_values)
+        """Return the type-strict member set, re-derived from the raw view."""
+        return _wrap_member_collection(self.valid_values)
 
     @classmethod
     @override
@@ -680,8 +857,9 @@ class NotInSetConstraint(Constraint):
 
     Symmetric to ``InSetConstraint``: ``evaluate`` reports ``SATISFIED``
     iff ``value`` is NOT in the constraint's value set and ``VIOLATED``
-    otherwise, comparing by type-strict equality. Membership is always
-    decidable, so this constraint never reports ``UNDECIDED``.
+    otherwise, comparing by type-strict equality. A membership check
+    against a concrete value is always decidable, so ``evaluate`` never
+    reports ``UNDECIDED``.
 
     Determinism:
         ``convert_to_expression`` emits its leaves in ``repr``-sorted
@@ -691,36 +869,36 @@ class NotInSetConstraint(Constraint):
 
     variable: Identifier = field(metadata=compared_as_reference())
     # Declared as the constructor-input type. ``__post_init__`` normalizes this
-    # in place to a ``frozenset[_TypedMember]``; read the members through the
-    # ``members`` property (raw values) or ``_members`` (internal wrappers)
-    # rather than this field directly.
+    # in place to a deduplicated tuple of raw, unwrapped values (the same
+    # content the ``members`` property exposes) so no public attribute ever
+    # yields the internal ``_TypedMember`` wrapper. Comparison uses
+    # ``compared_as_value(key=_wrap_member_collection)`` rather than the
+    # default ``==`` so structural/alpha equivalence stays type-strict and
+    # order-independent despite the field itself being a plain tuple.
     invalid_values: MemberCollection[ConstraintMember] = field(
         metadata={
-            **compared_as_value(),
+            **compared_as_value(key=_wrap_member_collection),
             "serialize_codec": _INVALID_VALUES_CODEC,
         },
     )
 
     def __post_init__(self) -> None:
+        wrapped = _normalize_constraint_member_collection(self.invalid_values)
         object.__setattr__(
             self,
             "invalid_values",
-            _normalize_constraint_member_collection(self.invalid_values),
+            tuple(_unwrap_member(member) for member in wrapped),
         )
 
     @property
     def members(self) -> tuple[ConstraintMember, ...]:
-        """Return the forbidden members as raw values.
-
-        The ``invalid_values`` field stores internal type-strict wrappers; this
-        accessor returns the unwrapped members in no particular order.
-        """
-        return tuple(_unwrap_member(member) for member in self._members)
+        """Return the forbidden members as raw values, in no particular order."""
+        return tuple(self.invalid_values)
 
     @property
     def _members(self) -> frozenset[_TypedMember]:
-        """Return the normalized, type-strict member set stored after init."""
-        return cast(frozenset[_TypedMember], self.invalid_values)
+        """Return the type-strict member set, re-derived from the raw view."""
+        return _wrap_member_collection(self.invalid_values)
 
     @classmethod
     @override
@@ -765,3 +943,365 @@ class NotInSetConstraint(Constraint):
     @override
     def __str__(self) -> str:
         return f"{self.variable} not in {_render_member_set_str(self._members)}"
+
+
+def _validate_symbol_types_cover_free_identifiers(
+    expression: Expression, symbol_types: Mapping[Identifier, SymbolType]
+) -> None:
+    """Raise if ``symbol_types`` lacks an entry for a free identifier of ``expression``.
+
+    Raises:
+        MissingSymbolTypeError: If one or more free identifiers of
+            ``expression`` have no corresponding ``symbol_types`` entry.
+
+    """
+    missing = expression.get_free_identifiers() - set(symbol_types)
+    if not missing:
+        return
+    missing_names = ", ".join(sorted(identifier.name_hint for identifier in missing))
+    raise MissingSymbolTypeError(
+        f"symbol_types is missing an entry for free identifier(s): {missing_names}."
+    )
+
+
+def _decide_satisfiability(
+    expression: Expression,
+    symbol_types: Mapping[Identifier, SymbolType],
+    *,
+    timeout_milliseconds: int | None = None,
+) -> ConstraintOutcome:
+    """Classify satisfiability of ``expression`` via the solver seam.
+
+    Raises:
+        MissingSymbolTypeError: If ``symbol_types`` lacks an entry for a
+            free identifier of ``expression``.
+
+    """
+    _validate_symbol_types_cover_free_identifiers(expression, symbol_types)
+    satisfiable = check_expression_satisfiability(
+        expression,
+        dict(symbol_types),
+        timeout_milliseconds=timeout_milliseconds,
+    )
+    if satisfiable is None:
+        return ConstraintOutcome.UNDECIDED
+    if satisfiable:
+        return ConstraintOutcome.SATISFIED
+    return ConstraintOutcome.VIOLATED
+
+
+def _contains_bool_literal(expression: Expression) -> bool:
+    """Return whether ``expression``'s tree contains a `bool`-valued literal.
+
+    Recurses via ``get_visit_children``, the same traversal
+    ``Expression.get_free_identifiers`` uses, so a nested
+    ``LiteralExpression`` is found regardless of depth. Checks
+    ``type(value) is bool`` rather than ``isinstance(value, bool)``,
+    matching ``LiteralExpression.__post_init__``'s own discrimination
+    between a ``bool`` value and a plain ``int`` value (``bool`` is an
+    ``int`` subclass).
+
+    """
+    if isinstance(expression, LiteralExpression) and type(expression.value) is bool:
+        return True
+    return any(
+        _contains_bool_literal(child) for child in expression.get_visit_children()
+    )
+
+
+def _find_bool_member_type_ambiguity(
+    constraints: tuple[Constraint, ...],
+    symbol_types: Mapping[Identifier, SymbolType],
+) -> bool:
+    """Return whether a `bool` literal among ``constraints`` is sort-ambiguous.
+
+    Two constructs hit the same Z3 coercion hazard:
+
+    - A ``bool`` member of an ``InSetConstraint``/``NotInSetConstraint``
+      lowers to a Z3 ``BoolVal``.
+    - A ``bool``-valued ``LiteralExpression`` anywhere in an
+      ``EquationConstraint``'s expression tree also lowers to a Z3
+      ``BoolVal``.
+
+    Compared against an ``IntVal``/``RealVal`` (whether that literal comes
+    from a free variable or from a bound identifier substituted to a
+    concrete value), the Z3 Python bindings silently coerce the
+    ``BoolVal`` into an integer via an implicit ``If`` (``True`` becomes
+    ``1``, ``False`` becomes ``0``). This collapses the type-strict
+    distinction the constraint's own ``evaluate``/``evaluate_with_bindings``
+    preserve whenever the bound value happens to be ``0`` or ``1``, so this
+    check does not special-case already-bound identifiers: only a variable
+    whose ``symbol_types`` entry is confirmed ``SymbolType.BOOL`` is
+    exempt -- for an ``EquationConstraint``, every free identifier of its
+    *expression* (not necessarily including its declared ``variable``,
+    which ``convert_to_expression`` does not add back in when the
+    expression does not itself reference it) must be confirmed
+    ``SymbolType.BOOL``, since the bool literal's position within the
+    expression tree is not tracked.
+
+    This is deliberately conservative: an ``EquationConstraint`` can hold a
+    ``bool`` literal that is never actually compared against a non-bool
+    identifier, in which case this still reports ambiguity. Over-triggering
+    only costs a spurious ``UNDECIDED``; the alternative -- a provably
+    wrong decided outcome -- is not acceptable.
+
+    """
+    for constraint in constraints:
+        if isinstance(constraint, (InSetConstraint, NotInSetConstraint)):
+            if symbol_types.get(constraint.variable) is SymbolType.BOOL:
+                continue
+            if any(isinstance(member, bool) for member in constraint.members):
+                return True
+        elif isinstance(constraint, EquationConstraint):
+            if not _contains_bool_literal(constraint.expression):
+                continue
+            if all(
+                symbol_types.get(identifier) is SymbolType.BOOL
+                for identifier in constraint.expression.get_free_identifiers()
+            ):
+                continue
+            return True
+    return False
+
+
+def create_constraint_system(*constraints: Constraint) -> "ConstraintSystem":
+    """Create a constraint system from the given constraints.
+
+    Args:
+        constraints: Zero or more constraints; identifiers shared between
+            constraints denote the same variable.
+
+    Returns:
+        A frozen ``ConstraintSystem`` holding the constraints in canonical
+        (repr-sorted) order.
+
+    Raises:
+        ConstraintError: If any argument is not a ``Constraint``.
+
+    """
+    return ConstraintSystem(constraints)
+
+
+@register_serializable(type_id="constraint_system")
+@dataclass(frozen=True, eq=False)
+class ConstraintSystem(WrappedFamilySerializable, FrozenMixin, DerivedEquivalenceMixin):
+    """An ordered conjunction of constraints over shared identifiers.
+
+    Semantically the logical AND of its member constraints. Constraints
+    are normalized into canonical (repr-sorted) order at construction, so
+    structurally equivalent systems built from differently ordered inputs
+    are structurally equivalent and serialize identically. Duplicate
+    constraints are retained (conjunction is idempotent). Instances are
+    frozen; mutation raises ``FrozenMutationError``.
+
+    ``ConstraintSystem`` is declared ``@dataclass(frozen=True, eq=False)``,
+    so ``__eq__`` and ``__hash__`` fall back to object identity rather than
+    comparing the ``constraints`` tuple. Two structurally equivalent
+    systems are therefore **distinct dict keys** and **distinct set
+    members**: use ``is_structurally_equivalent`` for value-equality
+    semantics, and avoid using ``ConstraintSystem`` instances as dict keys
+    when you expect value-based lookups.
+
+    """
+
+    constraints: tuple[Constraint, ...]
+
+    def __post_init__(self) -> None:
+        for constraint in self.constraints:
+            if not isinstance(constraint, Constraint):
+                raise ConstraintError(
+                    "ConstraintSystem members must be Constraint instances, "
+                    f"but got value {constraint!r} of type "
+                    f"{type(constraint).__name__}."
+                )
+        object.__setattr__(
+            self, "constraints", tuple(sorted(self.constraints, key=repr))
+        )
+
+    def get_free_identifiers(self) -> frozenset[Identifier]:
+        """Return the union of every member constraint's free identifiers."""
+        free: frozenset[Identifier] = frozenset()
+        for constraint in self.constraints:
+            free |= constraint.get_free_identifiers()
+        return free
+
+    def evaluate_with_bindings(self, bindings: ConstraintBindings) -> ConstraintOutcome:
+        """Return the conjunction outcome of all members under the bindings.
+
+        ``VIOLATED`` if any member is ``VIOLATED`` (a definite violation
+        dominates indeterminacy; members are checked in canonical order and
+        checking stops at the first violation); ``SATISFIED`` if every
+        member is ``SATISFIED``; ``UNDECIDED`` otherwise. The empty system
+        is vacuously ``SATISFIED``.
+
+        """
+        resolved_bindings = dict(bindings)
+        saw_undecided = False
+        for constraint in self.constraints:
+            outcome = constraint.evaluate_with_bindings(resolved_bindings)
+            if outcome is ConstraintOutcome.VIOLATED:
+                return ConstraintOutcome.VIOLATED
+            if outcome is ConstraintOutcome.UNDECIDED:
+                saw_undecided = True
+        return (
+            ConstraintOutcome.UNDECIDED
+            if saw_undecided
+            else ConstraintOutcome.SATISFIED
+        )
+
+    def is_satisfied_with_bindings(self, bindings: ConstraintBindings) -> bool:
+        """Return whether the bindings provably satisfy every constraint."""
+        return self.evaluate_with_bindings(bindings) is ConstraintOutcome.SATISFIED
+
+    def convert_to_expression(self) -> Expression:
+        """Return the conjunction of every member's expression form.
+
+        Empty system yields ``LiteralExpression(True)``; a single member
+        yields that member's expression unwrapped; otherwise a
+        ``logical_and`` over members in canonical order.
+
+        Raises:
+            ConstraintError: If any member cannot be expressed.
+
+        """
+        if not self.constraints:
+            return LiteralExpression(True)
+        expressions = [
+            constraint.convert_to_expression() for constraint in self.constraints
+        ]
+        if len(expressions) == 1:
+            return expressions[0]
+        return Expression.logical_and(*expressions)
+
+    def check_satisfiability(
+        self,
+        symbol_types: Mapping[Identifier, SymbolType],
+        *,
+        timeout_milliseconds: int | None = None,
+    ) -> ConstraintOutcome:
+        """Return whether some joint assignment satisfies every constraint.
+
+        Lowers ``convert_to_expression()`` to
+        ``solver.check_expression_satisfiability``: a satisfying
+        assignment provably exists -> ``SATISFIED``; provably none
+        exists -> ``VIOLATED``; solver ``unknown`` -> ``UNDECIDED``.
+        The empty system returns ``SATISFIED`` without invoking the
+        solver.
+
+        Limitation: a ``bool`` member of an ``InSetConstraint`` or
+        ``NotInSetConstraint`` whose variable's sort is not
+        ``SymbolType.BOOL``, or a ``bool``-valued literal anywhere in an
+        ``EquationConstraint``'s expression whose free identifiers are not
+        all ``SymbolType.BOOL``, cannot be lowered soundly through the
+        current Z3 bridge -- the Z3 Python bindings coerce a ``BoolVal``
+        compared against a non-bool sort into an integer (``True`` becomes
+        ``1``), collapsing the package's type-strict membership (and, for
+        an equation, literal-comparison) semantics. This method detects
+        both cases and returns ``UNDECIDED`` rather than a provably-wrong
+        decided outcome.
+
+        Args:
+            symbol_types: Z3 sort for each free identifier of the system.
+            timeout_milliseconds: Optional bound, in milliseconds, on the
+                underlying Z3 solver invocation. ``None`` (the default)
+                leaves the solver unbounded.
+
+        Raises:
+            MissingSymbolTypeError: If ``symbol_types`` lacks an entry for
+                a free identifier of the lowered conjunction. This is a
+                raise, not the ``ConstraintOutcome.UNDECIDED`` degradation
+                ``evaluate_with_bindings`` uses for a missing *value*
+                binding: a missing symbol type is a caller precondition
+                violation the Z3 bridge cannot proceed without, while a
+                missing value binding is an ordinary partial assignment
+                the symbolic evaluator can report as undecided.
+            ConstraintError: If a member cannot be converted to an
+                expression.
+            ValueError: If ``timeout_milliseconds`` is not None and not
+                positive.
+
+        """
+        if not self.constraints:
+            return ConstraintOutcome.SATISFIED
+        if _find_bool_member_type_ambiguity(self.constraints, symbol_types):
+            return ConstraintOutcome.UNDECIDED
+        return _decide_satisfiability(
+            self.convert_to_expression(),
+            symbol_types,
+            timeout_milliseconds=timeout_milliseconds,
+        )
+
+    def check_satisfiability_with_bindings(
+        self,
+        bindings: ConstraintBindings,
+        symbol_types: Mapping[Identifier, SymbolType],
+        *,
+        timeout_milliseconds: int | None = None,
+    ) -> ConstraintOutcome:
+        """Return whether the system is satisfiable given a partial assignment.
+
+        Substitutes the bindings into the conjunction, then decides
+        satisfiability of the residual over the remaining free identifiers
+        via the z3 bridge. ``symbol_types`` needs entries only for the
+        identifiers left free after substitution. Answers questions of the
+        form "given x = 4, can y and z still be chosen?".
+
+        Limitation: the same ``bool`` sort ambiguity documented on
+        ``check_satisfiability`` applies here, covering both the
+        set-membership case and the equation-constraint bool-literal case:
+        a system with a ``bool`` set member, or an ``EquationConstraint``
+        with a ``bool``-valued literal, whose relevant identifier(s) are
+        not confirmed ``SymbolType.BOOL`` returns ``UNDECIDED``, even when
+        ``bindings`` assigns those variables concrete values (Z3's sort
+        coercion can still misclassify a bound value of ``0`` or ``1``).
+
+        Args:
+            bindings: Partial assignment substituted into the conjunction
+                before the satisfiability check.
+            symbol_types: Z3 sort for each identifier left free after
+                substitution.
+            timeout_milliseconds: Optional bound, in milliseconds, on the
+                underlying Z3 solver invocation. ``None`` (the default)
+                leaves the solver unbounded.
+
+        Raises:
+            MissingSymbolTypeError: If ``symbol_types`` lacks an entry for
+                a free identifier of the residual expression left after
+                substitution. Contrast a missing entry in ``bindings``
+                itself: an identifier ``bindings`` does not cover is left
+                free in the residual rather than raising, so it only
+                raises here if ``symbol_types`` also fails to cover it. A
+                missing *value* binding degrades to
+                ``ConstraintOutcome.UNDECIDED`` on ``evaluate_with_bindings``;
+                a missing symbol type here always raises, since the Z3
+                bridge cannot proceed without a sort for every free
+                identifier.
+            ValueError: If ``timeout_milliseconds`` is not None and not
+                positive.
+
+        """
+        if not self.constraints:
+            return ConstraintOutcome.SATISFIED
+        if _find_bool_member_type_ambiguity(self.constraints, symbol_types):
+            return ConstraintOutcome.UNDECIDED
+        environment = _coerce_bindings_to_environment(bindings)
+        residual = self.convert_to_expression().substitute(environment)
+        return _decide_satisfiability(
+            residual, symbol_types, timeout_milliseconds=timeout_milliseconds
+        )
+
+    @classmethod
+    @override
+    def construct_from_fields(cls, fields: dict[str, Any]) -> "ConstraintSystem":
+        """Route deserialized fields through the constructor for re-validation."""
+        return cls(fields["constraints"])
+
+    @override
+    def __repr__(self) -> str:
+        return f"ConstraintSystem({format_comma_separated_list(self.constraints)})"
+
+    @override
+    def __str__(self) -> str:
+        if not self.constraints:
+            return "True"
+        return " and ".join(str(constraint) for constraint in self.constraints)

--- a/src/fhy_core/symbolic/solver.py
+++ b/src/fhy_core/symbolic/solver.py
@@ -23,6 +23,7 @@ __all__ = [
     "get_backend_capabilities",
     "holds_for_all_free_assignments",
     "simplify_expression",
+    "validate_timeout_milliseconds",
 ]
 
 from collections.abc import Set as AbstractSet
@@ -111,7 +112,20 @@ def _validate_backend_capability(
         )
 
 
-def _validate_timeout_milliseconds(timeout_milliseconds: int | None) -> None:
+def validate_timeout_milliseconds(timeout_milliseconds: int | None) -> None:
+    """Raise unless ``timeout_milliseconds`` is ``None`` or a positive integer.
+
+    Public so a caller that decides an outcome without reaching the solver
+    -- and therefore never passes the value on -- can still hold up the
+    same precondition the solver entry points enforce.
+
+    Args:
+        timeout_milliseconds: Candidate bound, in milliseconds.
+
+    Raises:
+        ValueError: If the value is not ``None`` and not positive.
+
+    """
     if timeout_milliseconds is not None and timeout_milliseconds <= 0:
         raise ValueError(
             "timeout_milliseconds must be None or a positive integer, but got "
@@ -199,7 +213,7 @@ def check_expression_satisfiability(
 
     """
     _validate_backend_capability(backend, SolverQueryKind.SATISFIABILITY)
-    _validate_timeout_milliseconds(timeout_milliseconds)
+    validate_timeout_milliseconds(timeout_milliseconds)
     # INVARIANT: _BACKEND_CAPABILITIES grants SATISFIABILITY to exactly one
     # backend (Z3), so delegating straight to the Z3 bridge is valid without
     # dispatching on `backend`. Adding a second SATISFIABILITY-capable
@@ -253,7 +267,7 @@ def does_expression_imply(
 
     """
     _validate_backend_capability(backend, SolverQueryKind.IMPLICATION)
-    _validate_timeout_milliseconds(timeout_milliseconds)
+    validate_timeout_milliseconds(timeout_milliseconds)
     # INVARIANT: _BACKEND_CAPABILITIES grants IMPLICATION to exactly one
     # backend (Z3), so delegating straight to the Z3 bridge is valid without
     # dispatching on `backend`. Adding a second IMPLICATION-capable backend
@@ -305,7 +319,7 @@ def holds_for_all_free_assignments(
 
     """
     _validate_backend_capability(backend, SolverQueryKind.UNIVERSAL_VALIDITY)
-    _validate_timeout_milliseconds(timeout_milliseconds)
+    validate_timeout_milliseconds(timeout_milliseconds)
     # INVARIANT: _BACKEND_CAPABILITIES grants UNIVERSAL_VALIDITY to exactly
     # one backend (Z3), so delegating straight to the Z3 bridge is valid
     # without dispatching on `backend`. Adding a second
@@ -350,7 +364,7 @@ def assert_holds_for_all_free_assignments(
 
     """
     _validate_backend_capability(backend, SolverQueryKind.UNIVERSAL_VALIDITY)
-    _validate_timeout_milliseconds(timeout_milliseconds)
+    validate_timeout_milliseconds(timeout_milliseconds)
     # INVARIANT: _BACKEND_CAPABILITIES grants UNIVERSAL_VALIDITY to exactly
     # one backend (Z3), so delegating straight to the Z3 bridge is valid
     # without dispatching on `backend`. Adding a second
@@ -396,7 +410,7 @@ def assert_expression_implies(
 
     """
     _validate_backend_capability(backend, SolverQueryKind.IMPLICATION)
-    _validate_timeout_milliseconds(timeout_milliseconds)
+    validate_timeout_milliseconds(timeout_milliseconds)
     # INVARIANT: _BACKEND_CAPABILITIES grants IMPLICATION to exactly one
     # backend (Z3), so delegating straight to the Z3 bridge is valid without
     # dispatching on `backend`. Adding a second IMPLICATION-capable backend

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,15 @@ def mock_identifier(name_hint: str, identifier_id: int) -> Identifier:
     identifier.__hash__ = MagicMock(  # type: ignore[method-assign]
         side_effect=lambda: hash(identifier.id)
     )
+    # `repr()` must be deterministic and content-based, matching the shape of
+    # the real `Identifier.__repr__` ("<name_hint>::<id>"), rather than
+    # Mock's default address-based form. Code under test canonicalizes by
+    # `repr` (e.g. `ConstraintSystem` sorts its members this way), so two
+    # independently constructed mocks for the same logical identifier must
+    # render identically.
+    identifier.__repr__ = MagicMock(  # type: ignore[method-assign]
+        side_effect=lambda: f"{identifier.name_hint}::{identifier.id}"
+    )
     identifier.serialize_to_dict = lambda: {
         "id": identifier.id,
         "name_hint": identifier.name_hint,

--- a/tests/symbolic/constraint/conftest.py
+++ b/tests/symbolic/constraint/conftest.py
@@ -23,6 +23,7 @@ from ..conftest import (  # re-exported below
 __all__ = [
     "ALL_KINDS",
     "SET_KINDS",
+    "HashCollidingMember",
     "HashableNotSerializable",
     "SerializableEqualHashable",
     "SerializableHashRaises",
@@ -131,6 +132,55 @@ class HashableNotSerializable:
         return (
             isinstance(other, HashableNotSerializable) and self._value == other._value
         )
+
+
+@register_serializable(type_id="tests.constraint.hash_colliding_member")
+class HashCollidingMember(Serializable):
+    """Serializable member whose instances all share one hash value.
+
+    Every instance hashes to the same number, so any two distinct
+    instances collide inside the ``frozenset`` that normalizes a set
+    constraint's members. Collisions are the only thing that makes a
+    ``frozenset``'s iteration order depend on insertion order, so a pair
+    of these members is what lets a test pin down that two constraints
+    built from differently ordered inputs really do store their members
+    in different orders -- and stay equivalent anyway. Members that do
+    not collide land in insertion-independent slots, which canonicalizes
+    the stored order and makes such a test unable to fail.
+
+    Distinct ``value``s stay unequal, so both survive normalization.
+    """
+
+    _value: int
+
+    def __init__(self, value: int) -> None:
+        self._value = value
+
+    @property
+    def value(self) -> int:
+        """Return the value distinguishing this member from its peers."""
+        return self._value
+
+    @override
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, HashCollidingMember) and self._value == other._value
+
+    @override
+    def __hash__(self) -> int:
+        return 0
+
+    @override
+    def __repr__(self) -> str:
+        return f"HashCollidingMember({self._value})"
+
+    @override
+    def serialize_to_dict(self) -> dict[str, Any]:
+        return {"value": self._value}
+
+    @classmethod
+    @override
+    def deserialize_from_dict(cls, data: dict[str, Any]) -> "HashCollidingMember":
+        return cls(value=int(data["value"]))
 
 
 def make_serializable_dict(type_id: str, data: Any) -> SerializedDict:

--- a/tests/symbolic/constraint/test_bindings_evaluation.py
+++ b/tests/symbolic/constraint/test_bindings_evaluation.py
@@ -518,3 +518,98 @@ def test_equation_constraint_free_identifiers_include_absent_variable() -> None:
     constraint = EquationConstraint(x, LiteralExpression(True))
 
     assert constraint.get_free_identifiers() == frozenset({x})
+
+
+# =============================================================================
+# Base-default bindings evaluation: reporting the cause of UNDECIDED
+# =============================================================================
+
+_CONSTRAINT_LOGGER = "fhy_core.symbolic.constraint"
+
+
+def _find_records(
+    caplog: pytest.LogCaptureFixture, level: int
+) -> list[logging.LogRecord]:
+    """Return the constraint module's records emitted at exactly ``level``."""
+    return [
+        record
+        for record in caplog.records
+        if record.levelno == level and record.name == _CONSTRAINT_LOGGER
+    ]
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_logs_debug_when_the_variable_is_unbound(
+    caplog: pytest.LogCaptureFixture, factory: SetConstraintFactory
+) -> None:
+    """Test a lookup miss on the constrained variable is reported at DEBUG.
+
+    A set constraint's ``evaluate`` never reports UNDECIDED, so under
+    bindings the only way to reach it is a missing entry for the
+    constrained variable. The record has to name the variable and the keys
+    that were supplied, which is what distinguishes a genuine partial
+    assignment from an identifier that fails to compare equal to the one
+    the constraint holds.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = factory(x, {1, 2})
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        outcome = constraint.evaluate_with_bindings({y: 1})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    debug_records = _find_records(caplog, logging.DEBUG)
+    assert debug_records, "expected a DEBUG record naming the unbound variable"
+    message = debug_records[0].getMessage()
+    assert repr(x) in message
+    assert repr(y) in message
+    assert not _find_records(caplog, logging.WARNING), (
+        "an unbound variable is an ordinary partial assignment, not an anomaly"
+    )
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_logs_debug_for_a_non_literal_expression_binding(
+    caplog: pytest.LogCaptureFixture, factory: SetConstraintFactory
+) -> None:
+    """Test a symbolic binding value the leaf cannot consume is reported at DEBUG.
+
+    ``ConstraintBindings`` admits any ``Expression`` value, but a
+    set-membership leaf can only decide against a concrete value. The
+    record has to name both the identifier and the expression that was
+    turned away, since nothing else distinguishes this from a missing
+    binding.
+    """
+    x = mock_identifier("x", 0)
+    w = mock_identifier("w", 1)
+    constraint = factory(x, {1, 2})
+    binding = IdentifierExpression(w)
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        outcome = constraint.evaluate_with_bindings({x: binding})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    debug_records = _find_records(caplog, logging.DEBUG)
+    assert debug_records, "expected a DEBUG record naming the rejected expression"
+    message = debug_records[0].getMessage()
+    assert repr(x) in message
+    assert repr(binding) in message
+    assert not _find_records(caplog, logging.WARNING), (
+        "a symbolic binding value is a structural limitation, not an anomaly"
+    )
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_logs_nothing_when_decidable(
+    caplog: pytest.LogCaptureFixture, factory: SetConstraintFactory
+) -> None:
+    """Test a decided outcome under bindings emits no record at any level."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2})
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        constraint.evaluate_with_bindings({x: 1})
+
+    assert not _find_records(caplog, logging.DEBUG)
+    assert not _find_records(caplog, logging.WARNING)

--- a/tests/symbolic/constraint/test_bindings_evaluation.py
+++ b/tests/symbolic/constraint/test_bindings_evaluation.py
@@ -1,0 +1,520 @@
+"""Tests for the multi-variable bindings evaluation API on `Constraint`."""
+
+import logging
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any
+
+import pytest
+
+from fhy_core.identifier import Identifier
+from fhy_core.symbolic.constraint import (
+    Constraint,
+    ConstraintOutcome,
+    EquationConstraint,
+    InSetConstraint,
+    NotInSetConstraint,
+)
+from fhy_core.symbolic.expression import (
+    BinaryOperation,
+    IdentifierExpression,
+    LiteralExpression,
+    LiteralType,
+    call,
+    make_binary_expression,
+)
+from fhy_core.utils.override import override
+
+from .conftest import ALL_KINDS, SET_KINDS, mock_identifier
+
+SetConstraintFactory = Callable[[Identifier, object], Constraint]
+ConstraintFactory = Callable[[Identifier], Constraint]
+
+# =============================================================================
+# Base-default bindings evaluation (set constraints)
+# =============================================================================
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_bound_value_matches_evaluate(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test a bound value under the constrained variable matches `evaluate`."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2, 3})
+
+    assert constraint.evaluate_with_bindings({x: 2}) == constraint.evaluate(2)
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_missing_variable_is_undecided(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test a bindings mapping missing the constrained variable is UNDECIDED."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = factory(x, {1, 2, 3})
+
+    assert constraint.evaluate_with_bindings({y: 2}) is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_unwraps_literal_expression_binding(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test a `LiteralExpression`-valued binding unwraps to match `evaluate`."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2, 3})
+
+    assert constraint.evaluate_with_bindings(
+        {x: LiteralExpression(2)}
+    ) == constraint.evaluate(2)
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_symbolic_expression_binding_is_undecided(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test a non-literal `Expression` binding cannot be decided by the default."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = factory(x, {1, 2, 3})
+
+    outcome = constraint.evaluate_with_bindings({x: IdentifierExpression(y)})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_ignores_extraneous_keys(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test identifiers the constraint does not reference are ignored."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = factory(x, {1, 2, 3})
+
+    assert constraint.evaluate_with_bindings({x: 2, y: 999}) == constraint.evaluate(2)
+
+
+def test_in_set_constraint_bindings_are_type_strict_for_bool_vs_int() -> None:
+    """Test a bound `True` is distinct from a member `1` under type-strict rules."""
+    x = mock_identifier("x", 0)
+    constraint = InSetConstraint(x, {1})
+
+    assert constraint.evaluate_with_bindings({x: True}) is ConstraintOutcome.VIOLATED
+
+
+def test_not_in_set_constraint_bindings_are_type_strict_for_bool_vs_int() -> None:
+    """Test a bound `True` is distinct from a forbidden member `1`."""
+    x = mock_identifier("x", 0)
+    constraint = NotInSetConstraint(x, {1})
+
+    assert constraint.evaluate_with_bindings({x: True}) is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_propagates_type_error_for_unhashable_value(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test an unhashable bound value propagates `TypeError`, matching `evaluate`."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2, 3})
+
+    with pytest.raises(TypeError):
+        constraint.evaluate_with_bindings({x: [1, 2]})  # type: ignore[dict-item]
+
+
+# =============================================================================
+# Base-default `evaluate_with_bindings` reads the mapping once (snapshot)
+# =============================================================================
+
+
+class _SingleReadMapping(Mapping[Identifier, Any]):
+    """A mapping that raises if any key is read from it more than once.
+
+    Used to prove the base ``evaluate_with_bindings`` default takes a
+    single snapshot of the caller's mapping rather than performing a
+    membership check and a separate lookup against the live mapping
+    (which would read the same key twice).
+    """
+
+    def __init__(self, data: dict[Identifier, Any]) -> None:
+        self._data = dict(data)
+        self._read_counts: dict[Identifier, int] = {}
+
+    @override
+    def __iter__(self) -> Iterator[Identifier]:
+        return iter(self._data)
+
+    @override
+    def __len__(self) -> int:
+        return len(self._data)
+
+    @override
+    def __getitem__(self, key: Identifier) -> Any:
+        self._read_counts[key] = self._read_counts.get(key, 0) + 1
+        if self._read_counts[key] > 1:
+            raise AssertionError(f"{key!r} was read more than once from the mapping")
+        return self._data[key]
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_bindings_reads_the_mapping_only_once(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test the base default snapshots the mapping instead of re-reading it."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2, 3})
+    bindings = _SingleReadMapping({x: 2})
+
+    outcome = constraint.evaluate_with_bindings(bindings)
+
+    assert outcome == constraint.evaluate(2)
+
+
+# =============================================================================
+# `EquationConstraint.evaluate_with_bindings` override
+# =============================================================================
+
+
+def _build_sum_less_than_ten(x: Identifier, y: Identifier) -> EquationConstraint:
+    expression = make_binary_expression(
+        BinaryOperation.LESS,
+        make_binary_expression(BinaryOperation.ADD, x, y),
+        10,
+    )
+    return EquationConstraint(x, expression)
+
+
+def test_equation_constraint_bindings_full_assignment_satisfied() -> None:
+    """Test a full multi-variable assignment that holds reports SATISFIED."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = _build_sum_less_than_ten(x, y)
+
+    outcome = constraint.evaluate_with_bindings({x: 3, y: 5})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+def test_equation_constraint_bindings_full_assignment_violated() -> None:
+    """Test a full multi-variable assignment that fails reports VIOLATED."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = _build_sum_less_than_ten(x, y)
+
+    outcome = constraint.evaluate_with_bindings({x: 20, y: 1})
+
+    assert outcome is ConstraintOutcome.VIOLATED
+
+
+def test_equation_constraint_bindings_partial_assignment_is_undecided() -> None:
+    """Test binding only one of two free identifiers is UNDECIDED."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = _build_sum_less_than_ten(x, y)
+
+    outcome = constraint.evaluate_with_bindings({x: 3})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_equation_constraint_bindings_empty_undecided_for_open_expression() -> None:
+    """Test an empty bindings mapping is UNDECIDED for an open expression."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = _build_sum_less_than_ten(x, y)
+
+    outcome = constraint.evaluate_with_bindings({})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_equation_constraint_bindings_empty_satisfied_for_closed_expression() -> None:
+    """Test an empty bindings mapping decides a closed (variable-free) expression."""
+    x = mock_identifier("x", 0)
+    constraint = EquationConstraint(x, LiteralExpression(True))
+
+    outcome = constraint.evaluate_with_bindings({})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+def test_equation_constraint_bindings_symbolic_binding_can_decide() -> None:
+    """Test a symbolic (non-literal) binding can still decide the outcome."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    expression = make_binary_expression(BinaryOperation.GREATER, x, y)
+    constraint = EquationConstraint(x, expression)
+    successor_of_y = make_binary_expression(
+        BinaryOperation.ADD, IdentifierExpression(y), 1
+    )
+
+    outcome = constraint.evaluate_with_bindings({x: successor_of_y})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+def test_equation_constraint_bindings_chained_assignment_is_undecided() -> None:
+    """Test a chained binding leaves a residual instead of folding through it.
+
+    ``{x: y, y: 5}`` must not be applied sequentially (``x -> y -> 5``,
+    folding ``x < 5`` to the literal ``False``/VIOLATED); simultaneous
+    substitution leaves the residual ``y < 5``, which is UNDECIDED because
+    ``y`` remains free.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = EquationConstraint(
+        x, make_binary_expression(BinaryOperation.LESS, x, 5)
+    )
+
+    outcome = constraint.evaluate_with_bindings({x: IdentifierExpression(y), y: 5})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_equation_constraint_bindings_swap_assignment_on_equality_is_undecided() -> (
+    None
+):
+    """Test a swap binding on `x - y == 0` is UNDECIDED, not SATISFIED.
+
+    Sequential substitution would resolve `x - y == 0` to `y - y == 0`
+    (SATISFIED); simultaneous substitution swaps the identifiers instead,
+    leaving an undecided residual comparing two distinct identifiers.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    expression = make_binary_expression(
+        BinaryOperation.EQUAL,
+        make_binary_expression(BinaryOperation.SUBTRACT, x, y),
+        0,
+    )
+    constraint = EquationConstraint(x, expression)
+
+    outcome = constraint.evaluate_with_bindings(
+        {x: IdentifierExpression(y), y: IdentifierExpression(x)}
+    )
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_equation_constraint_bindings_swap_assignment_on_inequality_is_undecided() -> (
+    None
+):
+    """Test a swap binding on `x < y` is UNDECIDED, not VIOLATED.
+
+    Sequential substitution would resolve `x < y` to `y < y` (VIOLATED);
+    simultaneous substitution swaps the identifiers instead, leaving an
+    undecided residual comparing two distinct identifiers.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = EquationConstraint(
+        x, make_binary_expression(BinaryOperation.LESS, x, y)
+    )
+
+    outcome = constraint.evaluate_with_bindings(
+        {x: IdentifierExpression(y), y: IdentifierExpression(x)}
+    )
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_equation_constraint_bindings_ignores_extraneous_keys() -> None:
+    """Test bindings for identifiers outside the expression do not affect the result."""
+    x = mock_identifier("x", 0)
+    z = mock_identifier("z", 2)
+    constraint = EquationConstraint(x, LiteralExpression(True))
+
+    outcome = constraint.evaluate_with_bindings({z: 999})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+# =============================================================================
+# DEBUG-vs-WARNING logging split
+# =============================================================================
+
+
+def test_equation_constraint_bindings_logs_debug_when_free_identifiers_unbound(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test partial bindings log at DEBUG, not WARNING."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = _build_sum_less_than_ten(x, y)
+
+    with caplog.at_level(logging.DEBUG, logger="fhy_core.symbolic.constraint"):
+        outcome = constraint.evaluate_with_bindings({x: 3})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    assert any(
+        record.levelno == logging.DEBUG
+        and record.name == "fhy_core.symbolic.constraint"
+        for record in caplog.records
+    ), "expected a DEBUG-level log record from fhy_core.symbolic.constraint"
+    assert not any(record.levelno == logging.WARNING for record in caplog.records), (
+        "a partial (expected) UNDECIDED case must not log a warning"
+    )
+
+
+def test_equation_constraint_bindings_logs_debug_for_symbolic_residual(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a symbolic binding that leaves the residual open logs at DEBUG.
+
+    Every free identifier of the *original* expression is bound here, but
+    the bound value is itself a symbolic ``Expression`` referencing a new
+    identifier, so the substituted-and-simplified residual still has a
+    free identifier. This is classified the same as an ordinary partial
+    assignment (DEBUG), not the fully-grounded anomaly case (WARNING).
+    """
+    x = mock_identifier("x", 0)
+    w = mock_identifier("w", 1)
+    constraint = EquationConstraint(
+        x, make_binary_expression(BinaryOperation.LESS, x, 10)
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="fhy_core.symbolic.constraint"):
+        outcome = constraint.evaluate_with_bindings({x: IdentifierExpression(w)})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    assert any(
+        record.levelno == logging.DEBUG
+        and record.name == "fhy_core.symbolic.constraint"
+        for record in caplog.records
+    ), "expected a DEBUG-level log record from fhy_core.symbolic.constraint"
+    assert not any(record.levelno == logging.WARNING for record in caplog.records), (
+        "a residual that still has a free identifier must not log a warning"
+    )
+
+
+def test_equation_constraint_bindings_logs_warning_when_fully_bound_but_irreducible(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a fully bound, fully closed, yet irreducible residual logs at WARNING.
+
+    ``arcsin`` is not registered as a native-constant-foldable function
+    for an out-of-domain argument, so ``simplify_expression`` returns an
+    unevaluated ``CallExpression`` with no free identifiers at all: every
+    free identifier was bound, but the simplifier still failed to reduce
+    the residual to a literal -- the genuine anomaly case.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = EquationConstraint(x, call("arcsin", IdentifierExpression(y)))
+
+    with caplog.at_level(logging.DEBUG, logger="fhy_core.symbolic.constraint"):
+        outcome = constraint.evaluate_with_bindings({y: 2})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    assert any(
+        record.levelno == logging.WARNING
+        and record.name == "fhy_core.symbolic.constraint"
+        for record in caplog.records
+    ), "expected a WARNING-level log record from fhy_core.symbolic.constraint"
+    assert not any(record.levelno == logging.DEBUG for record in caplog.records), (
+        "a fully-bound, fully-closed irreducible residual must not log at debug"
+    )
+
+
+# =============================================================================
+# `evaluate` / `evaluate_with_bindings` equivalence
+# =============================================================================
+
+
+@pytest.mark.parametrize("factory", ALL_KINDS)
+@pytest.mark.parametrize("value", [1, True, 2.5])
+def test_evaluate_matches_evaluate_with_bindings_for_raw_value(
+    factory: ConstraintFactory, value: LiteralType
+) -> None:
+    """Test `evaluate(v)` matches `evaluate_with_bindings({variable: v})`."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x)
+
+    assert constraint.evaluate(value) == constraint.evaluate_with_bindings({x: value})
+
+
+def test_equation_constraint_evaluate_matches_bindings_for_expression_value() -> None:
+    """Test the equivalence also holds when the single binding is an `Expression`."""
+    x = mock_identifier("x", 0)
+    constraint = EquationConstraint(x, IdentifierExpression(x))
+    value = LiteralExpression(True)
+
+    assert constraint.evaluate(value) == constraint.evaluate_with_bindings({x: value})
+
+
+# =============================================================================
+# `is_satisfied_with_bindings`
+# =============================================================================
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_is_satisfied_with_bindings_folds_undecided_to_false(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test an UNDECIDED bindings outcome maps to `False`."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = factory(x, {1, 2, 3})
+
+    assert constraint.evaluate_with_bindings({y: 2}) is ConstraintOutcome.UNDECIDED
+    assert constraint.is_satisfied_with_bindings({y: 2}) is False
+
+
+def test_equation_constraint_is_satisfied_with_bindings_folds_undecided_to_false() -> (
+    None
+):
+    """Test an UNDECIDED bindings outcome maps to `False` for an equation."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = EquationConstraint(x, IdentifierExpression(y))
+
+    assert constraint.evaluate_with_bindings({}) is ConstraintOutcome.UNDECIDED
+    assert constraint.is_satisfied_with_bindings({}) is False
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_is_satisfied_with_bindings_true_when_satisfied(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test a decided SATISFIED bindings outcome maps to `True`."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2, 3})
+
+    assert constraint.evaluate_with_bindings({x: 2}) == constraint.evaluate(2)
+    assert constraint.is_satisfied_with_bindings({x: 2}) == constraint.is_satisfied(2)
+
+
+# =============================================================================
+# `get_free_identifiers`
+# =============================================================================
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_free_identifiers_is_just_the_variable(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test a set constraint's free identifiers is exactly its variable."""
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2})
+
+    assert constraint.get_free_identifiers() == frozenset({x})
+
+
+def test_equation_constraint_free_identifiers_unions_variable_and_expression() -> None:
+    """Test an equation's free identifiers include the variable and the expression."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = EquationConstraint(x, IdentifierExpression(y))
+
+    assert constraint.get_free_identifiers() == frozenset({x, y})
+
+
+def test_equation_constraint_free_identifiers_include_absent_variable() -> None:
+    """Test the variable is always included even when absent from the expression."""
+    x = mock_identifier("x", 0)
+    constraint = EquationConstraint(x, LiteralExpression(True))
+
+    assert constraint.get_free_identifiers() == frozenset({x})

--- a/tests/symbolic/constraint/test_bindings_evaluation.py
+++ b/tests/symbolic/constraint/test_bindings_evaluation.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Callable, Iterator, Mapping
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from fhy_core.identifier import Identifier
 from fhy_core.symbolic.constraint import (
     Constraint,
+    ConstraintError,
     ConstraintOutcome,
     EquationConstraint,
     InSetConstraint,
@@ -330,6 +332,104 @@ def test_equation_constraint_bindings_ignores_extraneous_keys() -> None:
     outcome = constraint.evaluate_with_bindings({z: 999})
 
     assert outcome is ConstraintOutcome.SATISFIED
+
+
+# =============================================================================
+# Binding-value construction boundary
+# =============================================================================
+
+OFF_UNION_BINDING_VALUES = [
+    pytest.param(None, id="none"),
+    pytest.param(Decimal("1"), id="decimal"),
+    pytest.param([1, 2], id="list"),
+    pytest.param(object(), id="object"),
+]
+"""Parametrize list of values outside ``Expression | LiteralType``.
+
+``ConstraintBindings`` admits none of these; each reaches the API only
+from code the type checker has not seen or has been silenced on, which is
+exactly the case the runtime boundary has to answer for.
+"""
+
+
+@pytest.mark.parametrize("value", OFF_UNION_BINDING_VALUES)
+def test_equation_constraint_bindings_rejects_a_value_outside_the_declared_union(
+    value: Any,
+) -> None:
+    """Test a binding value outside `Expression | LiteralType` raises.
+
+    ``ConstraintBindings`` declares ``Expression | LiteralType``. A value
+    in neither arm cannot be lifted into the substitution environment, so
+    the override rejects it at the boundary with a domain error naming the
+    identifier, the value, and its type, rather than letting it reach the
+    expression passes as an internal error.
+    """
+    x = mock_identifier("x", 0)
+    constraint = EquationConstraint(
+        x, make_binary_expression(BinaryOperation.LESS, x, 10)
+    )
+
+    with pytest.raises(ConstraintError) as exception_info:
+        constraint.evaluate_with_bindings({x: value})
+
+    message = str(exception_info.value)
+    assert repr(x) in message
+    assert repr(value) in message
+    assert type(value).__name__ in message
+
+
+def test_equation_constraint_bindings_names_the_offending_identifier_only() -> None:
+    """Test the boundary error names the bad binding, not an acceptable one."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    constraint = _build_sum_less_than_ten(x, y)
+
+    with pytest.raises(ConstraintError) as exception_info:
+        constraint.evaluate_with_bindings({x: 3, y: None})  # type: ignore[dict-item]
+
+    message = str(exception_info.value)
+    assert repr(y) in message
+    assert repr(x) not in message
+
+
+def test_equation_constraint_bindings_admits_a_non_literal_expression_value() -> None:
+    """Test a symbolic `Expression` binding crosses the boundary unchanged.
+
+    A non-literal expression is supported input, not a boundary
+    violation: the residual it leaves behind is reported UNDECIDED rather
+    than rejected.
+    """
+    x = mock_identifier("x", 0)
+    w = mock_identifier("w", 1)
+    constraint = EquationConstraint(
+        x, make_binary_expression(BinaryOperation.LESS, x, 10)
+    )
+
+    outcome = constraint.evaluate_with_bindings({x: IdentifierExpression(w)})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize(
+    "value",
+    [pytest.param(None, id="none"), pytest.param(Decimal("1"), id="decimal")],
+)
+def test_set_constraint_bindings_forwards_a_value_outside_the_declared_union(
+    factory: SetConstraintFactory, value: Any
+) -> None:
+    """Test the base default forwards an off-union value to `evaluate`.
+
+    The base default has no expression to lift the value into, so it hands
+    the value to ``evaluate``, whose ``Any`` contract governs: a hashable
+    value outside the declared union is simply not a member and the check
+    stays decided. Nothing internal escapes, which is what makes this path
+    coherent with the ``EquationConstraint`` override's rejection.
+    """
+    x = mock_identifier("x", 0)
+    constraint = factory(x, {1, 2, 3})
+
+    assert constraint.evaluate_with_bindings({x: value}) == constraint.evaluate(value)
 
 
 # =============================================================================

--- a/tests/symbolic/constraint/test_constraint_system.py
+++ b/tests/symbolic/constraint/test_constraint_system.py
@@ -1,0 +1,1130 @@
+"""Tests for `ConstraintSystem` and `create_constraint_system`."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import pytest
+
+from fhy_core.identifier import Identifier
+from fhy_core.serialization import (
+    DeserializationDictStructureError,
+    DeserializationValueError,
+    FieldCodec,
+    SerializationFormat,
+    SerializationValueError,
+    make_field_codec,
+)
+from fhy_core.symbolic.constraint import (
+    Constraint,
+    ConstraintBindings,
+    ConstraintError,
+    ConstraintOutcome,
+    ConstraintSystem,
+    EquationConstraint,
+    InSetConstraint,
+    MissingSymbolTypeError,
+    NotInSetConstraint,
+    create_constraint_system,
+)
+from fhy_core.symbolic.expression import (
+    BinaryExpression,
+    BinaryOperation,
+    Expression,
+    IdentifierExpression,
+    LiteralExpression,
+    make_binary_expression,
+)
+from fhy_core.symbolic.symbol_type import SymbolType
+from fhy_core.term import (
+    compared_as_reference,
+    compared_as_value,
+    excluded_from_equivalence,
+)
+from fhy_core.traits import Frozen, FrozenMutationError
+from fhy_core.utils.override import override
+
+from .conftest import SerializableEqualHashable, mock_identifier
+
+# =============================================================================
+# Test helper: a fully callback-driven constraint
+# =============================================================================
+
+# ``_ProbeConstraint`` is never serialized; this codec only exists to satisfy
+# the schema-derived serialization engine's field-inference pass, which has no
+# built-in support for a ``Callable``-typed field.
+_UNUSED_CALLBACK_CODEC: FieldCodec = make_field_codec(
+    lambda _value: None, lambda _data: lambda *_a, **_k: None
+)
+
+
+@dataclass(frozen=True, eq=False)
+class _ProbeConstraint(Constraint):
+    """Constraint whose evaluation is fully driven by an injected callback.
+
+    Lets a test observe which members were evaluated, in what order, and
+    with what bindings snapshot, without depending on any other kind's
+    ``repr`` (whose mock-identifier form is not controllable) for canonical
+    ordering: ``label`` drives a deterministic, test-controlled ``repr``.
+    """
+
+    variable: Identifier = field(metadata=compared_as_reference())
+    label: str = field(metadata=compared_as_value())
+    # Annotated with ``Mapping[Identifier, Any]`` (rather than the
+    # ``ConstraintBindings`` alias) because this is a dataclass field: the
+    # serialization/frozen engines resolve field annotations from this
+    # module's own globals, and ``ConstraintBindings`` embeds a
+    # module-relative forward reference that only resolves against
+    # ``fhy_core.symbolic.constraint``'s namespace.
+    on_evaluate_with_bindings: Callable[
+        [Mapping[Identifier, Any]], ConstraintOutcome
+    ] = field(
+        metadata={
+            **excluded_from_equivalence(),
+            "serialize_codec": _UNUSED_CALLBACK_CODEC,
+        }
+    )
+
+    @override
+    def evaluate(self, value: Any) -> ConstraintOutcome:
+        return self.on_evaluate_with_bindings({self.variable: value})
+
+    @override
+    def evaluate_with_bindings(self, bindings: ConstraintBindings) -> ConstraintOutcome:
+        return self.on_evaluate_with_bindings(bindings)
+
+    @override
+    def convert_to_expression(self) -> Expression:
+        return LiteralExpression(True)
+
+    @override
+    def __repr__(self) -> str:
+        return f"_ProbeConstraint({self.label})"
+
+    @override
+    def __str__(self) -> str:
+        return self.label
+
+
+# =============================================================================
+# Factory / construction
+# =============================================================================
+
+
+def test_create_constraint_system_with_no_arguments_is_empty() -> None:
+    """Test the factory with no arguments produces an empty system."""
+    system = create_constraint_system()
+
+    assert system.constraints == ()
+
+
+def test_create_constraint_system_rejects_non_constraint_element() -> None:
+    """Test a non-`Constraint` argument raises `ConstraintError`."""
+    with pytest.raises(ConstraintError):
+        create_constraint_system("not-a-constraint")  # type: ignore[arg-type]
+
+
+def test_create_constraint_system_rejects_nested_constraint_system() -> None:
+    """Test a nested `ConstraintSystem` argument raises `ConstraintError`."""
+    x = mock_identifier("x", 0)
+    inner = create_constraint_system(InSetConstraint(x, {1, 2}))
+
+    with pytest.raises(ConstraintError):
+        create_constraint_system(inner)  # type: ignore[arg-type]
+
+
+def test_create_constraint_system_retains_duplicate_constraints() -> None:
+    """Test conjunction retains duplicate members rather than deduplicating."""
+    x = mock_identifier("x", 0)
+    member = InSetConstraint(x, {1, 2})
+
+    system = create_constraint_system(member, member)
+
+    assert len(system.constraints) == 2
+
+
+# =============================================================================
+# Canonical ordering and structural equivalence
+# =============================================================================
+
+
+def test_create_constraint_system_orders_members_same_regardless_of_order() -> None:
+    """Test the same members in different input order produce the same tuple."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    a = InSetConstraint(x, {1, 2})
+    b = InSetConstraint(y, {3, 4})
+
+    system_ab = create_constraint_system(a, b)
+    system_ba = create_constraint_system(b, a)
+
+    assert system_ab.constraints == system_ba.constraints
+
+
+def test_constraint_system_structural_equivalence_ignores_construction_order() -> None:
+    """Test independently built, differently ordered systems are equivalent."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    left = create_constraint_system(
+        InSetConstraint(x, {1, 2}), InSetConstraint(y, {3, 4})
+    )
+    right = create_constraint_system(
+        InSetConstraint(y, {3, 4}), InSetConstraint(x, {1, 2})
+    )
+
+    assert left.is_structurally_equivalent(right)
+    assert right.is_structurally_equivalent(left)
+
+
+def test_constraint_system_structural_equivalence_false_for_different_members() -> None:
+    """Test systems with different member constraints are not equivalent."""
+    x = mock_identifier("x", 0)
+    left = create_constraint_system(InSetConstraint(x, {1, 2}))
+    right = create_constraint_system(InSetConstraint(x, {1, 2, 3}))
+
+    assert not left.is_structurally_equivalent(right)
+
+
+def test_constraint_system_canonicalizes_alike_for_independent_identifiers() -> None:
+    """Test independently constructed, content-identical systems canonicalize alike.
+
+    Two separate ``mock_identifier`` calls with the same name and id are
+    distinct ``Mock`` objects, but ``ConstraintSystem`` orders its members
+    by ``repr``. A deterministic, content-based mock ``repr`` is required
+    for two independently built systems over "the same" identifiers, given
+    in different construction order, to canonicalize to the same member
+    order.
+    """
+    x1, y1 = mock_identifier("x", 0), mock_identifier("y", 1)
+    x2, y2 = mock_identifier("x", 0), mock_identifier("y", 1)
+    left = create_constraint_system(
+        InSetConstraint(x1, {1, 2}), InSetConstraint(y1, {3, 4})
+    )
+    right = create_constraint_system(
+        InSetConstraint(y2, {3, 4}), InSetConstraint(x2, {1, 2})
+    )
+
+    assert [repr(c) for c in left.constraints] == [repr(c) for c in right.constraints]
+    assert left.convert_to_expression().is_structurally_equivalent(
+        right.convert_to_expression()
+    )
+
+
+# =============================================================================
+# Frozen contract
+# =============================================================================
+
+
+def test_constraint_system_implements_frozen_protocol_and_is_frozen() -> None:
+    """Test a constructed system satisfies `Frozen` and reports `is_frozen`."""
+    system = create_constraint_system()
+
+    assert isinstance(system, Frozen)
+    assert system.is_frozen
+
+
+def test_constraint_system_rejects_arbitrary_attribute_assignment() -> None:
+    """Test setattr on a frozen system raises `FrozenMutationError`."""
+    system = create_constraint_system()
+
+    with pytest.raises(FrozenMutationError):
+        system.arbitrary_probe = "mutation"
+
+
+# =============================================================================
+# repr / str
+# =============================================================================
+
+
+def test_constraint_system_repr_includes_class_name_and_member_reprs() -> None:
+    """Test `repr` includes the class name and each member's repr."""
+    x = mock_identifier("x", 0)
+    member = InSetConstraint(x, {1, 2})
+    system = create_constraint_system(member)
+
+    rendered = repr(system)
+
+    assert "ConstraintSystem" in rendered
+    assert repr(member) in rendered
+
+
+def test_constraint_system_str_includes_member_str_forms() -> None:
+    """Test `str` includes each member's `str` form."""
+    x = mock_identifier("x", 0)
+    member = InSetConstraint(x, {1, 2})
+    system = create_constraint_system(member)
+
+    assert str(member) in str(system)
+
+
+def test_constraint_system_str_empty_system_denotes_trivially_true() -> None:
+    """Test the empty system's `str` denotes the trivially true conjunction."""
+    system = create_constraint_system()
+
+    assert str(system) == "True"
+
+
+# =============================================================================
+# `get_free_identifiers`
+# =============================================================================
+
+
+def test_get_free_identifiers_unions_every_members_free_identifiers() -> None:
+    """Test the system's free identifiers union every member's."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    z = mock_identifier("z", 2)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), EquationConstraint(y, IdentifierExpression(z))
+    )
+
+    assert system.get_free_identifiers() == frozenset({x, y, z})
+
+
+def test_get_free_identifiers_empty_system_is_empty() -> None:
+    """Test the empty system's free identifiers is the empty set."""
+    system = create_constraint_system()
+
+    assert system.get_free_identifiers() == frozenset()
+
+
+# =============================================================================
+# `evaluate_with_bindings` / `is_satisfied_with_bindings`
+# =============================================================================
+
+
+def test_evaluate_with_bindings_empty_system_is_vacuously_satisfied() -> None:
+    """Test the empty system is vacuously SATISFIED under any bindings."""
+    system = create_constraint_system()
+
+    assert system.evaluate_with_bindings({}) is ConstraintOutcome.SATISFIED
+
+
+def test_evaluate_with_bindings_all_members_satisfied_is_satisfied() -> None:
+    """Test the conjunction is SATISFIED when every member is SATISFIED."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), InSetConstraint(y, {3, 4})
+    )
+
+    outcome = system.evaluate_with_bindings({x: 1, y: 3})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+def test_evaluate_with_bindings_violated_dominates_undecided() -> None:
+    """Test a VIOLATED member dominates a co-occurring UNDECIDED member."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), InSetConstraint(y, {3, 4})
+    )
+
+    outcome = system.evaluate_with_bindings({x: 99})
+
+    assert outcome is ConstraintOutcome.VIOLATED
+
+
+def test_evaluate_with_bindings_undecided_without_any_violation() -> None:
+    """Test the conjunction is UNDECIDED with no VIOLATED member but not all decided."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), InSetConstraint(y, {3, 4})
+    )
+
+    outcome = system.evaluate_with_bindings({x: 1})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_evaluate_with_bindings_stops_at_first_violation() -> None:
+    """Test evaluation stops after the first VIOLATED member in canonical order."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    calls: list[str] = []
+
+    def violate(_bindings: ConstraintBindings) -> ConstraintOutcome:
+        calls.append("first")
+        return ConstraintOutcome.VIOLATED
+
+    def satisfy(_bindings: ConstraintBindings) -> ConstraintOutcome:
+        calls.append("second")
+        return ConstraintOutcome.SATISFIED
+
+    first = _ProbeConstraint(x, "a", violate)
+    second = _ProbeConstraint(y, "b", satisfy)
+    system = create_constraint_system(first, second)
+
+    outcome = system.evaluate_with_bindings({})
+
+    assert outcome is ConstraintOutcome.VIOLATED
+    assert calls == ["first"]
+
+
+def test_evaluate_with_bindings_uses_a_stable_snapshot_of_the_mapping() -> None:
+    """Test a caller mutating the bindings mid-call does not affect later members."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    bindings: dict[Any, Any] = {x: 1, y: 3}
+    seen_by_second: list[Any] = []
+
+    def mutate_then_satisfy(_bindings: ConstraintBindings) -> ConstraintOutcome:
+        bindings[y] = 999
+        return ConstraintOutcome.SATISFIED
+
+    def record_y_and_satisfy(seen_bindings: ConstraintBindings) -> ConstraintOutcome:
+        seen_by_second.append(seen_bindings.get(y))
+        return ConstraintOutcome.SATISFIED
+
+    first = _ProbeConstraint(x, "a", mutate_then_satisfy)
+    second = _ProbeConstraint(y, "b", record_y_and_satisfy)
+    system = create_constraint_system(first, second)
+
+    system.evaluate_with_bindings(bindings)
+
+    assert seen_by_second == [3]
+
+
+def test_is_satisfied_with_bindings_folds_undecided_to_false() -> None:
+    """Test an UNDECIDED conjunction outcome maps to `False`."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), InSetConstraint(y, {3, 4})
+    )
+
+    assert system.evaluate_with_bindings({x: 1}) is ConstraintOutcome.UNDECIDED
+    assert system.is_satisfied_with_bindings({x: 1}) is False
+
+
+def test_is_satisfied_with_bindings_true_when_all_members_satisfied() -> None:
+    """Test a SATISFIED conjunction outcome maps to `True`."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2}))
+
+    assert system.is_satisfied_with_bindings({x: 1}) is True
+
+
+def test_evaluate_with_bindings_propagates_type_error_for_unhashable_value() -> None:
+    """Test an unhashable bound value propagates `TypeError` from a member."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2}))
+
+    with pytest.raises(TypeError):
+        system.evaluate_with_bindings({x: [1, 2]})  # type: ignore[dict-item]
+
+
+# =============================================================================
+# `convert_to_expression`
+# =============================================================================
+
+
+def test_convert_to_expression_empty_system_is_literal_true() -> None:
+    """Test the empty system converts to the literal `True`."""
+    system = create_constraint_system()
+
+    expression = system.convert_to_expression()
+
+    assert isinstance(expression, LiteralExpression)
+    assert expression.value is True
+
+
+def test_convert_to_expression_single_member_is_unwrapped() -> None:
+    """Test a single-member system's expression is that member's own expression."""
+    x = mock_identifier("x", 0)
+    member = InSetConstraint(x, {1, 2})
+    system = create_constraint_system(member)
+
+    expression = system.convert_to_expression()
+
+    assert expression.is_structurally_equivalent(member.convert_to_expression())
+
+
+def test_convert_to_expression_multi_member_is_a_logical_and() -> None:
+    """Test a multi-member system's expression is a top-level LOGICAL_AND."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), InSetConstraint(y, {3, 4})
+    )
+
+    expression = system.convert_to_expression()
+
+    assert isinstance(expression, BinaryExpression)
+    assert expression.operation is BinaryOperation.LOGICAL_AND
+
+
+def test_convert_to_expression_propagates_constraint_error_from_a_member() -> None:
+    """Test a member's `ConstraintError` during conversion propagates."""
+    x = mock_identifier("x", 0)
+    member = InSetConstraint(x, {SerializableEqualHashable(1)})
+    system = create_constraint_system(member)
+
+    with pytest.raises(ConstraintError):
+        system.convert_to_expression()
+
+
+# =============================================================================
+# Serialization
+# =============================================================================
+
+
+def test_serialize_to_dict_uses_the_pinned_type_id() -> None:
+    """Test the wrapped envelope uses the pinned `constraint_system` type id."""
+    system = create_constraint_system()
+
+    payload = system.serialize_to_dict()
+
+    assert payload["__type__"] == "constraint_system"
+
+
+def test_round_trip_dict_preserves_mixed_kind_members() -> None:
+    """Test a mixed-kind system round-trips through dict serialization."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), EquationConstraint(y, LiteralExpression(True))
+    )
+
+    rebuilt = ConstraintSystem.deserialize_from_dict(system.serialize_to_dict())
+
+    assert isinstance(rebuilt, ConstraintSystem)
+    assert rebuilt.is_structurally_equivalent(system)
+
+
+def test_round_trip_through_json_format() -> None:
+    """Test a system round-trips through the JSON serialization format."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2}))
+
+    rebuilt = ConstraintSystem.deserialize(
+        system.serialize(SerializationFormat.JSON), SerializationFormat.JSON
+    )
+
+    assert rebuilt.is_structurally_equivalent(system)
+
+
+def test_round_trip_through_binary_format() -> None:
+    """Test a system round-trips through the binary serialization format."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2}))
+
+    rebuilt = ConstraintSystem.deserialize(
+        system.serialize(SerializationFormat.BINARY), SerializationFormat.BINARY
+    )
+
+    assert rebuilt.is_structurally_equivalent(system)
+
+
+def test_empty_system_round_trips_through_dict_serialization() -> None:
+    """Test the empty system round-trips and stays empty."""
+    system = create_constraint_system()
+
+    rebuilt = ConstraintSystem.deserialize_from_dict(system.serialize_to_dict())
+
+    assert rebuilt.constraints == ()
+
+
+def test_wire_members_are_emitted_in_repr_sorted_order() -> None:
+    """Test serialized members are emitted in the same order as `constraints`."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2}), EquationConstraint(y, LiteralExpression(True))
+    )
+
+    payload_data = cast(dict[str, Any], system.serialize_to_dict()["__data__"])
+    wrapped_members = cast(list[dict[str, Any]], payload_data["constraints"])
+
+    assert [member["__type__"] for member in wrapped_members] == [
+        constraint.get_serialization_class_type_id()
+        for constraint in system.constraints
+    ]
+
+
+def test_deserialize_data_from_dict_rejects_missing_constraints_field() -> None:
+    """Test a missing `constraints` field raises a structure error."""
+    with pytest.raises(DeserializationDictStructureError):
+        ConstraintSystem.deserialize_data_from_dict({})
+
+
+def test_deserialize_data_from_dict_rejects_non_list_constraints_field() -> None:
+    """Test a non-list `constraints` field raises a structure error."""
+    with pytest.raises(DeserializationDictStructureError):
+        ConstraintSystem.deserialize_data_from_dict({"constraints": "not-a-list"})
+
+
+def test_deserialize_data_from_dict_rejects_malformed_member_entry() -> None:
+    """Test a malformed member entry raises a deserialization error."""
+    with pytest.raises((DeserializationValueError, DeserializationDictStructureError)):
+        ConstraintSystem.deserialize_data_from_dict(
+            {"constraints": [{"not_a_wrapped_value": "value"}]}
+        )
+
+
+def test_json_serialization_rejects_a_nan_member() -> None:
+    """Test a NaN-valued member propagates the module's NaN-rejection contract."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {float("nan")}))
+
+    with pytest.raises(SerializationValueError):
+        system.to_json()
+
+
+# =============================================================================
+# `check_satisfiability` / `check_satisfiability_with_bindings` (z3-backed)
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_check_satisfiability_is_satisfied_for_a_satisfiable_system() -> None:
+    """Test a satisfiable multi-variable system reports SATISFIED."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT, y: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_is_violated_for_an_unsatisfiable_strict_cycle() -> None:
+    """Test a strict cyclic ordering constraint (x<y<z<x) is unsatisfiable."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    z = mock_identifier("z", 2)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y)),
+        EquationConstraint(y, make_binary_expression(BinaryOperation.LESS, y, z)),
+        EquationConstraint(z, make_binary_expression(BinaryOperation.LESS, z, x)),
+    )
+
+    outcome = system.check_satisfiability(
+        {x: SymbolType.INT, y: SymbolType.INT, z: SymbolType.INT}
+    )
+
+    assert outcome is ConstraintOutcome.VIOLATED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_mixed_set_and_equation_system_is_satisfiable() -> None:
+    """Test a mixed set-and-equation system is satisfiable without rewriting."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2, 3}),
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y)),
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT, y: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_mixed_set_and_equation_system_is_unsatisfiable() -> None:
+    """Test a mixed set-and-equation system can be jointly unsatisfiable."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        InSetConstraint(x, {1, 2, 3}),
+        EquationConstraint(x, make_binary_expression(BinaryOperation.GREATER, x, 100)),
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.VIOLATED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_raises_missing_symbol_type_error() -> None:
+    """Test a missing `symbol_types` entry raises `MissingSymbolTypeError` naming it."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
+    )
+
+    with pytest.raises(MissingSymbolTypeError, match=y.name_hint):
+        system.check_satisfiability({x: SymbolType.INT})
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_raises_missing_symbol_type_error() -> None:
+    """Test a missing `symbol_types` entry for a residual free identifier raises.
+
+    Mirrors ``test_check_satisfiability_raises_missing_symbol_type_error``
+    for the bindings-aware entry point: the entry is missing for an
+    identifier left free after substitution, not for a bound one.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
+    )
+
+    with pytest.raises(MissingSymbolTypeError, match=y.name_hint):
+        system.check_satisfiability_with_bindings({x: 5}, {})
+
+
+def test_evaluate_with_bindings_missing_value_binding_degrades_to_undecided() -> None:
+    """Test a missing value binding is UNDECIDED, contrasting a missing symbol type.
+
+    Uses the same system and missing identifier as
+    ``test_check_satisfiability_raises_missing_symbol_type_error``: a
+    missing VALUE binding here degrades gracefully to UNDECIDED, unlike a
+    missing SYMBOL TYPE on the Z3-backed satisfiability methods, which raises.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
+    )
+
+    outcome = system.evaluate_with_bindings({x: 1})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_check_satisfiability_empty_system_does_not_invoke_the_solver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the empty system short-circuits to SATISFIED without calling z3."""
+
+    def _fail_if_called(*args: object, **kwargs: object) -> bool | None:
+        raise AssertionError("check_expression_satisfiability must not be called")
+
+    monkeypatch.setattr(
+        "fhy_core.symbolic.constraint.check_expression_satisfiability", _fail_if_called
+    )
+    system = create_constraint_system()
+
+    outcome = system.check_satisfiability({})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_matches_the_documented_example() -> None:
+    """Test `{x: 5}` on `{x<y, y<3}` is VIOLATED after substitution."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y)),
+        EquationConstraint(y, make_binary_expression(BinaryOperation.LESS, y, 3)),
+    )
+
+    outcome = system.check_satisfiability_with_bindings({x: 5}, {y: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.VIOLATED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_satisfiable_after_substitution() -> None:
+    """Test a partial assignment can leave the residual system satisfiable."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y)),
+        EquationConstraint(y, make_binary_expression(BinaryOperation.LESS, y, 30)),
+    )
+
+    outcome = system.check_satisfiability_with_bindings({x: 5}, {y: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_closed_conjunction_needs_no_symbol_types() -> None:
+    """Test a system whose expression has no free identifiers needs no symbol types."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(EquationConstraint(x, LiteralExpression(True)))
+
+    outcome = system.check_satisfiability({})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+def test_check_satisfiability_with_bindings_empty_system_does_not_invoke_the_solver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test the empty system short-circuits to SATISFIED without calling z3.
+
+    Mirrors ``test_check_satisfiability_empty_system_does_not_invoke_the_solver``
+    for the bindings-aware entry point.
+    """
+
+    def _fail_if_called(*args: object, **kwargs: object) -> bool | None:
+        raise AssertionError("check_expression_satisfiability must not be called")
+
+    monkeypatch.setattr(
+        "fhy_core.symbolic.constraint.check_expression_satisfiability", _fail_if_called
+    )
+    system = create_constraint_system()
+
+    outcome = system.check_satisfiability_with_bindings({}, {})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_constants_only_needs_no_symbol_types() -> (
+    None
+):
+    """Test a constants-only system needs no symbol types with empty bindings.
+
+    Mirrors ``test_check_satisfiability_with_closed_conjunction_needs_no_symbol_types``
+    for the bindings-aware entry point: with no bindings supplied, the
+    residual is the same closed expression, which needs no symbol types.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(EquationConstraint(x, LiteralExpression(True)))
+
+    outcome = system.check_satisfiability_with_bindings({}, {})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+# =============================================================================
+# `evaluate_with_bindings` / `check_satisfiability_with_bindings` cross-path
+# agreement (z3-backed)
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_evaluate_and_check_satisfiability_with_bindings_do_not_contradict() -> None:
+    """Test the two bindings-aware APIs never reach opposite decided outcomes.
+
+    For a chained binding such as ``{x: y, y: 5}`` on ``x < 5``,
+    ``evaluate_with_bindings`` and ``check_satisfiability_with_bindings``
+    (which substitutes through the always-simultaneous IR-level
+    ``Expression.substitute``) must agree: neither reports VIOLATED
+    while the other reports SATISFIED or UNDECIDED on the residual
+    ``y < 5``.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, 5))
+    )
+    bindings: ConstraintBindings = {x: IdentifierExpression(y), y: 5}
+
+    evaluate_outcome = system.evaluate_with_bindings(bindings)
+    satisfiability_outcome = system.check_satisfiability_with_bindings(
+        bindings, {y: SymbolType.INT}
+    )
+
+    assert evaluate_outcome is not ConstraintOutcome.VIOLATED
+    assert satisfiability_outcome is not ConstraintOutcome.VIOLATED
+
+
+# =============================================================================
+# Bool set-member sort ambiguity (z3-backed)
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_check_satisfiability_bool_member_ambiguity_is_undecided_not_violated() -> None:
+    """Test a bool-ambiguous system that is type-strictly satisfiable reports UNDECIDED.
+
+    ``x`` typed ``INT`` with ``x in {1}`` and ``x not in {True}`` is
+    satisfied by the concrete witness ``x = 1`` under the package's
+    type-strict membership semantics (``evaluate_with_bindings`` agrees).
+    The Z3 bridge cannot preserve that distinction when lowering the bool
+    member (Z3 coerces ``BoolVal(True)`` against an ``Int`` sort to the
+    integer ``1``), so ``check_satisfiability`` reports UNDECIDED rather
+    than the provably wrong VIOLATED.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        InSetConstraint(x, {1}), NotInSetConstraint(x, {True})
+    )
+
+    assert system.evaluate_with_bindings({x: 1}) is ConstraintOutcome.SATISFIED
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_bool_member_under_int_sort_is_not_satisfied() -> None:
+    """Test a bool member under a non-bool sort is never reported SATISFIED.
+
+    No admissible ``int`` value type-strictly equals ``True``, so a
+    system whose only constraint is ``x in {True}`` under an ``INT`` sort
+    must not be reported SATISFIED; Z3's coercion of ``True`` to the
+    integer ``1`` would otherwise let ``x = 1`` spuriously satisfy it.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {True}))
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is not ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_bool_member_under_bool_sort_is_unaffected() -> None:
+    """Test a bool member under a `BOOL`-sorted variable still decides soundly.
+
+    The sort-ambiguity guard must be specific to non-``BOOL`` sorts; a
+    variable that is itself ``BOOL``-typed has no coercion ambiguity and
+    should still be decided.
+    """
+    b = mock_identifier("b", 0)
+    system = create_constraint_system(InSetConstraint(b, {True, False}))
+
+    outcome = system.check_satisfiability({b: SymbolType.BOOL})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_bindings_bool_member_colliding_int_is_undecided() -> None:
+    """Test a bool-ambiguous variable bound to a colliding int stays UNDECIDED.
+
+    ``x != True`` is type-strictly SATISFIED for any bound int (``1`` is
+    never ``True``), but Z3 lowers ``True`` to the integer ``1``, so
+    binding ``x`` to exactly ``1`` would otherwise let the sort coercion
+    report the provably-wrong VIOLATED. The ambiguity guard does not
+    special-case bound identifiers, precisely to catch this collision.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(NotInSetConstraint(x, {True}))
+
+    assert system.evaluate_with_bindings({x: 1}) is ConstraintOutcome.SATISFIED
+    outcome = system.check_satisfiability_with_bindings({x: 1}, {})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+# =============================================================================
+# Bool literal sort ambiguity in an `EquationConstraint` (z3-backed)
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_check_satisfiability_equation_bool_literal_ambiguity_is_undecided() -> None:
+    """Test an equation's bool literal against a non-bool variable is UNDECIDED.
+
+    ``x == True`` with ``x`` typed ``INT`` has no honest ``INT`` witness:
+    the only value that actually satisfies it is the ``bool`` ``True``
+    itself (``constraint.evaluate(True)`` is SATISFIED), which is not an
+    ``int`` at all, and every genuine ``int`` -- including ``1``, the
+    value Z3's coercion identifies ``True`` with -- provably VIOLATES it
+    under the package's type-strict semantics (``constraint.evaluate(1)``
+    is VIOLATED). The Z3 bridge does not see this distinction: it lowers
+    the bool literal ``True`` to the integer ``1`` and would spuriously
+    decide the system SATISFIED at ``x = 1``, contradicting
+    ``evaluate(1)``. Both satisfiability APIs must report UNDECIDED
+    instead of that provably wrong decided outcome.
+    """
+    x = mock_identifier("x", 0)
+    constraint = EquationConstraint(
+        x,
+        make_binary_expression(
+            BinaryOperation.EQUAL, IdentifierExpression(x), LiteralExpression(True)
+        ),
+    )
+    system = create_constraint_system(constraint)
+
+    assert constraint.evaluate(1) is ConstraintOutcome.VIOLATED
+    assert constraint.evaluate(True) is ConstraintOutcome.SATISFIED
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+    outcome_with_bindings = system.check_satisfiability_with_bindings(
+        {}, {x: SymbolType.INT}
+    )
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    assert outcome_with_bindings is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_equation_bool_literal_under_bool_sort_is_unaffected() -> (
+    None
+):
+    """Test the guard exempts an equation whose only free identifier is BOOL-typed.
+
+    The sort-ambiguity guard must be specific to non-``BOOL`` sorts; a
+    variable that is itself ``BOOL``-typed has no coercion ambiguity, so
+    ``x == True`` under a ``BOOL`` sort should still be decided.
+    """
+    x = mock_identifier("x", 0)
+    constraint = EquationConstraint(
+        x,
+        make_binary_expression(
+            BinaryOperation.EQUAL, IdentifierExpression(x), LiteralExpression(True)
+        ),
+    )
+    system = create_constraint_system(constraint)
+
+    outcome = system.check_satisfiability({x: SymbolType.BOOL})
+    outcome_with_bindings = system.check_satisfiability_with_bindings(
+        {}, {x: SymbolType.BOOL}
+    )
+
+    assert outcome is ConstraintOutcome.SATISFIED
+    assert outcome_with_bindings is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_set_ambiguity_survives_equation_branch() -> None:
+    """Test the pre-existing set-constraint bool-ambiguity guard still fires.
+
+    Guards against a regression where extending the ambiguity check to
+    ``EquationConstraint`` could shadow or short-circuit the original
+    ``InSetConstraint``/``NotInSetConstraint`` branch: a bool-ambiguous set
+    constraint alongside an ordinary (non-bool-literal) equation
+    constraint must still be reported UNDECIDED.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        InSetConstraint(x, {True}),
+        EquationConstraint(y, make_binary_expression(BinaryOperation.LESS, y, 5)),
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT, y: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+# =============================================================================
+# `timeout_milliseconds` passthrough (z3-backed)
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_check_satisfiability_forwards_timeout_milliseconds_to_the_solver_seam(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test `check_satisfiability` forwards `timeout_milliseconds` to the solver."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2, 3}))
+    captured: dict[str, Any] = {}
+
+    def _fake_check(
+        expression: Expression,
+        symbol_types: dict[Identifier, SymbolType],
+        *,
+        timeout_milliseconds: int | None = None,
+    ) -> bool | None:
+        captured["timeout_milliseconds"] = timeout_milliseconds
+        return True
+
+    monkeypatch.setattr(
+        "fhy_core.symbolic.constraint.check_expression_satisfiability", _fake_check
+    )
+
+    outcome = system.check_satisfiability(
+        {x: SymbolType.INT}, timeout_milliseconds=2500
+    )
+
+    assert outcome is ConstraintOutcome.SATISFIED
+    assert captured["timeout_milliseconds"] == 2500
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_forwards_timeout_milliseconds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test `check_satisfiability_with_bindings` forwards `timeout_milliseconds`."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
+    )
+    captured: dict[str, Any] = {}
+
+    def _fake_check(
+        expression: Expression,
+        symbol_types: dict[Identifier, SymbolType],
+        *,
+        timeout_milliseconds: int | None = None,
+    ) -> bool | None:
+        captured["timeout_milliseconds"] = timeout_milliseconds
+        return True
+
+    monkeypatch.setattr(
+        "fhy_core.symbolic.constraint.check_expression_satisfiability", _fake_check
+    )
+
+    outcome = system.check_satisfiability_with_bindings(
+        {x: 1}, {y: SymbolType.INT}, timeout_milliseconds=1000
+    )
+
+    assert outcome is ConstraintOutcome.SATISFIED
+    assert captured["timeout_milliseconds"] == 1000
+
+
+# =============================================================================
+# Solver `unknown` result (`None`) maps to `UNDECIDED`
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_check_satisfiability_solver_unknown_result_is_undecided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test `check_satisfiability` maps a solver `None` (unknown) result to UNDECIDED.
+
+    Complements the `timeout_milliseconds` passthrough tests above, which
+    patch the same seam but always return `True`: this covers the
+    `_decide_satisfiability` branch where the solver itself is
+    inconclusive.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2, 3}))
+
+    def _fake_check(
+        expression: Expression,
+        symbol_types: dict[Identifier, SymbolType],
+        *,
+        timeout_milliseconds: int | None = None,
+    ) -> bool | None:
+        return None
+
+    monkeypatch.setattr(
+        "fhy_core.symbolic.constraint.check_expression_satisfiability", _fake_check
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_solver_unknown_result_is_undecided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test `check_satisfiability_with_bindings` maps solver `None` to UNDECIDED.
+
+    Mirrors `test_check_satisfiability_solver_unknown_result_is_undecided`
+    for the bindings-aware entry point.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
+    )
+
+    def _fake_check(
+        expression: Expression,
+        symbol_types: dict[Identifier, SymbolType],
+        *,
+        timeout_milliseconds: int | None = None,
+    ) -> bool | None:
+        return None
+
+    monkeypatch.setattr(
+        "fhy_core.symbolic.constraint.check_expression_satisfiability", _fake_check
+    )
+
+    outcome = system.check_satisfiability_with_bindings({x: 1}, {y: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.UNDECIDED

--- a/tests/symbolic/constraint/test_constraint_system.py
+++ b/tests/symbolic/constraint/test_constraint_system.py
@@ -318,6 +318,36 @@ def test_constraint_system_rejects_arbitrary_attribute_assignment() -> None:
 
 
 # =============================================================================
+# Identity equality
+# =============================================================================
+
+
+def test_constraint_system_equality_is_identity_not_structure() -> None:
+    """Test two structurally equivalent systems stay distinct values.
+
+    The class documents identity equality as a caller-visible contract:
+    equivalent systems are distinct dict keys and distinct set members, and
+    ``is_structurally_equivalent`` is the value-equality operation. Both
+    systems are built from the same two member instances in opposite
+    order, so canonical ordering makes their ``constraints`` tuples
+    identical -- structural equality would collapse them, and only
+    identity equality keeps them apart.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    first_member = InSetConstraint(x, {1, 2})
+    second_member = InSetConstraint(y, {3, 4})
+    first = create_constraint_system(first_member, second_member)
+    second = create_constraint_system(second_member, first_member)
+
+    assert first.is_structurally_equivalent(second)
+    assert first.constraints == second.constraints
+    assert first != second
+    assert len({first, second}) == 2
+    assert len({first: "first", second: "second"}) == 2
+
+
+# =============================================================================
 # repr / str
 # =============================================================================
 
@@ -341,6 +371,22 @@ def test_constraint_system_str_includes_member_str_forms() -> None:
     system = create_constraint_system(member)
 
     assert str(member) in str(system)
+
+
+def test_constraint_system_str_joins_multiple_members_as_a_conjunction() -> None:
+    """Test `str` separates members with the conjunction the system denotes.
+
+    A system is the logical AND of its members, so the separator is part
+    of the rendered meaning; a single-member system never shows it.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    first_member = InSetConstraint(x, {1, 2})
+    second_member = InSetConstraint(y, {3, 4})
+    system = create_constraint_system(first_member, second_member)
+
+    assert system.constraints == (first_member, second_member)
+    assert str(system) == f"{first_member} and {second_member}"
 
 
 def test_constraint_system_str_empty_system_denotes_trivially_true() -> None:
@@ -491,6 +537,24 @@ def test_is_satisfied_with_bindings_true_when_all_members_satisfied() -> None:
     system = create_constraint_system(InSetConstraint(x, {1, 2}))
 
     assert system.is_satisfied_with_bindings({x: 1}) is True
+
+
+def test_evaluate_with_bindings_rejects_a_value_outside_the_declared_union() -> None:
+    """Test an off-union binding value surfaces as a `ConstraintError`.
+
+    ``ConstraintBindings`` declares ``Expression | LiteralType``; a value
+    in neither arm must be reported as a domain error naming the
+    identifier rather than escaping as an expression-pass failure.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, 10))
+    )
+
+    with pytest.raises(ConstraintError) as exception_info:
+        system.evaluate_with_bindings({x: None})  # type: ignore[dict-item]
+
+    assert repr(x) in str(exception_info.value)
 
 
 def test_evaluate_with_bindings_propagates_type_error_for_unhashable_value() -> None:
@@ -727,6 +791,39 @@ def test_check_satisfiability_mixed_set_and_equation_system_is_unsatisfiable() -
 
 
 @pytest.mark.z3
+def test_check_satisfiability_needs_sorts_only_for_the_lowered_conjunction() -> None:
+    """Test `symbol_types` need not cover an identifier the lowering drops.
+
+    ``EquationConstraint.get_free_identifiers`` always reports its
+    ``variable``, but ``convert_to_expression`` emits only the expression,
+    so a ``variable`` the expression never references is absent from the
+    lowered conjunction. ``symbol_types`` is keyed on what is lowered, not
+    on ``get_free_identifiers()``, which is a strict superset here.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(EquationConstraint(x, IdentifierExpression(y)))
+
+    assert system.get_free_identifiers() == frozenset({x, y})
+    assert system.convert_to_expression().get_free_identifiers() == frozenset({y})
+    assert system.check_satisfiability({y: SymbolType.BOOL}) is (
+        ConstraintOutcome.SATISFIED
+    )
+
+
+def _extract_reported_missing_names(error: MissingSymbolTypeError) -> str:
+    """Return the identifier listing a `MissingSymbolTypeError` message carries.
+
+    The listing is everything after the message's final ``": "``. Reading
+    it out separately keeps an assertion off the fixed prefix, which
+    already contains several of the single-character name hints the tests
+    use and would otherwise satisfy a substring match no matter which
+    identifier the error actually reported.
+    """
+    return str(error).rpartition(": ")[2].rstrip(".")
+
+
+@pytest.mark.z3
 def test_check_satisfiability_raises_missing_symbol_type_error() -> None:
     """Test a missing `symbol_types` entry raises `MissingSymbolTypeError` naming it."""
     x = mock_identifier("x", 0)
@@ -735,8 +832,10 @@ def test_check_satisfiability_raises_missing_symbol_type_error() -> None:
         EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
     )
 
-    with pytest.raises(MissingSymbolTypeError, match=y.name_hint):
+    with pytest.raises(MissingSymbolTypeError) as exception_info:
         system.check_satisfiability({x: SymbolType.INT})
+
+    assert _extract_reported_missing_names(exception_info.value) == y.name_hint
 
 
 @pytest.mark.z3
@@ -753,8 +852,35 @@ def test_check_satisfiability_with_bindings_raises_missing_symbol_type_error() -
         EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y))
     )
 
-    with pytest.raises(MissingSymbolTypeError, match=y.name_hint):
+    with pytest.raises(MissingSymbolTypeError) as exception_info:
         system.check_satisfiability_with_bindings({x: 5}, {})
+
+    assert _extract_reported_missing_names(exception_info.value) == y.name_hint
+
+
+@pytest.mark.z3
+def test_check_satisfiability_reports_every_missing_identifier_in_sorted_order() -> (
+    None
+):
+    """Test two missing entries are both reported, ordered by name hint.
+
+    The identifiers are declared so that their ``id`` order (which drives
+    the free-identifier set's iteration order) is the reverse of their
+    name-hint order, so a listing that skipped the sort would come out
+    ``b, a``.
+    """
+    b = mock_identifier("b", 0)
+    a = mock_identifier("a", 1)
+    system = create_constraint_system(
+        EquationConstraint(b, make_binary_expression(BinaryOperation.LESS, b, a))
+    )
+
+    with pytest.raises(MissingSymbolTypeError) as exception_info:
+        system.check_satisfiability({})
+
+    assert _extract_reported_missing_names(exception_info.value) == (
+        f"{a.name_hint}, {b.name_hint}"
+    )
 
 
 def test_evaluate_with_bindings_missing_value_binding_degrades_to_undecided() -> None:
@@ -774,6 +900,63 @@ def test_evaluate_with_bindings_missing_value_binding_degrades_to_undecided() ->
     outcome = system.evaluate_with_bindings({x: 1})
 
     assert outcome is ConstraintOutcome.UNDECIDED
+
+
+def test_check_satisfiability_with_bindings_rejects_an_off_union_binding_value() -> (
+    None
+):
+    """Test an off-union binding value raises before the conjunction is lowered.
+
+    The bindings are coerced into a substitution environment ahead of the
+    solver, so a value in neither arm of ``Expression | LiteralType`` has
+    to be reported as a domain error naming the identifier rather than
+    escaping as an expression-pass failure.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, 10))
+    )
+
+    with pytest.raises(ConstraintError) as exception_info:
+        system.check_satisfiability_with_bindings(
+            {x: None},  # type: ignore[dict-item]
+            {x: SymbolType.INT},
+        )
+
+    assert repr(x) in str(exception_info.value)
+
+
+def test_check_satisfiability_propagates_constraint_error_from_a_member() -> None:
+    """Test a member that cannot be lowered raises `ConstraintError`.
+
+    ``check_satisfiability`` reaches the member through
+    ``convert_to_expression``, so a member whose value set holds a
+    non-literal must surface the documented ``ConstraintError`` rather
+    than an outcome.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        InSetConstraint(x, {SerializableEqualHashable(1)})
+    )
+
+    with pytest.raises(ConstraintError):
+        system.check_satisfiability({x: SymbolType.INT})
+
+
+def test_check_satisfiability_with_bindings_propagates_constraint_error() -> None:
+    """Test the bindings entry point raises `ConstraintError` for the same member.
+
+    ``check_satisfiability_with_bindings`` calls ``convert_to_expression``
+    exactly as ``check_satisfiability`` does, so it shares the documented
+    ``ConstraintError`` failure mode.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        InSetConstraint(x, {SerializableEqualHashable(1)})
+    )
+
+    with pytest.raises(ConstraintError):
+        system.check_satisfiability_with_bindings({}, {x: SymbolType.INT})
 
 
 def test_check_satisfiability_empty_system_does_not_invoke_the_solver(

--- a/tests/symbolic/constraint/test_constraint_system.py
+++ b/tests/symbolic/constraint/test_constraint_system.py
@@ -1,5 +1,6 @@
 """Tests for `ConstraintSystem` and `create_constraint_system`."""
 
+import logging
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, cast
@@ -1496,3 +1497,208 @@ def test_check_satisfiability_with_bindings_solver_unknown_result_is_undecided(
     outcome = system.check_satisfiability_with_bindings({x: 1}, {y: SymbolType.INT})
 
     assert outcome is ConstraintOutcome.UNDECIDED
+
+
+# =============================================================================
+# Reporting the cause of an undecided outcome
+# =============================================================================
+
+_CONSTRAINT_LOGGER = "fhy_core.symbolic.constraint"
+
+
+def _find_records(
+    caplog: pytest.LogCaptureFixture, level: int
+) -> list[logging.LogRecord]:
+    """Return the constraint module's records emitted at exactly ``level``."""
+    return [
+        record
+        for record in caplog.records
+        if record.levelno == level and record.name == _CONSTRAINT_LOGGER
+    ]
+
+
+def test_check_satisfiability_logs_warning_for_the_bool_coercion_hazard(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the bool sort-hazard screen reports what it refused to lower.
+
+    Returning UNDECIDED here is a capability gap in the Z3 bridge, not
+    ordinary partial evaluation, so it warns -- and it names the offending
+    node and the identifier sort involved, because a caller who cannot see
+    either has no way to tell this apart from a solver timeout and will
+    reach for ``timeout_milliseconds``, which cannot help.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {True}))
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    warnings = _find_records(caplog, logging.WARNING)
+    assert warnings, "expected a WARNING naming the hazardous node"
+    message = warnings[0].getMessage()
+    assert "check_satisfiability" in message
+    assert repr(x) in message
+    assert SymbolType.INT.name in message
+
+
+def test_check_satisfiability_with_bindings_logs_warning_for_the_bool_coercion_hazard(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the residual screened after substitution reports the same way."""
+    y = mock_identifier("y", 0)
+    system = create_constraint_system(NotInSetConstraint(y, {1}))
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        outcome = system.check_satisfiability_with_bindings({y: True}, {})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    warnings = _find_records(caplog, logging.WARNING)
+    assert warnings, "expected a WARNING naming the hazardous node"
+    message = warnings[0].getMessage()
+    assert "check_satisfiability_with_bindings" in message
+
+
+@pytest.mark.z3
+def test_check_satisfiability_logs_nothing_when_the_solver_decides(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a decided satisfiability check emits no record at any level."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2}))
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+    assert not _find_records(caplog, logging.WARNING)
+    assert not _find_records(caplog, logging.DEBUG)
+
+
+def test_system_evaluate_with_bindings_logs_debug_naming_the_undecided_member(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the system reports which member left the conjunction undecided.
+
+    A system-level UNDECIDED that names no member forces the caller to
+    re-check every constraint by hand to find the one that could not be
+    decided.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    undecided_member = InSetConstraint(y, {1, 2})
+    system = create_constraint_system(InSetConstraint(x, {1, 2}), undecided_member)
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        outcome = system.evaluate_with_bindings({x: 1})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+    messages = [record.getMessage() for record in _find_records(caplog, logging.DEBUG)]
+    assert any(
+        "ConstraintSystem" in message and repr(undecided_member) in message
+        for message in messages
+    ), "expected a DEBUG record from the system naming the undecided member"
+
+
+def test_system_evaluate_with_bindings_logs_nothing_when_every_member_decides(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a fully decided system emits no record at any level."""
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {1, 2}))
+
+    with caplog.at_level(logging.DEBUG, logger=_CONSTRAINT_LOGGER):
+        outcome = system.evaluate_with_bindings({x: 1})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+    assert not _find_records(caplog, logging.DEBUG)
+    assert not _find_records(caplog, logging.WARNING)
+
+
+# =============================================================================
+# `timeout_milliseconds` validation on the paths that skip the solver
+# =============================================================================
+
+_INVALID_TIMEOUTS = [
+    pytest.param(-5, id="negative"),
+    pytest.param(0, id="zero"),
+]
+"""Values ``timeout_milliseconds`` must reject; only ``None`` or positive pass."""
+
+
+def _build_bool_hazard_system(variable: Identifier) -> ConstraintSystem:
+    """Return a system whose lowering trips the Boolean-coercion screen."""
+    return create_constraint_system(InSetConstraint(variable, {True}))
+
+
+@pytest.mark.parametrize("timeout_milliseconds", _INVALID_TIMEOUTS)
+def test_check_satisfiability_rejects_invalid_timeout_for_an_empty_system(
+    timeout_milliseconds: int,
+) -> None:
+    """Test the empty system validates ``timeout_milliseconds`` before returning.
+
+    The empty system is vacuously satisfiable and never reaches the
+    solver, but the documented contract promises the raise
+    unconditionally, so the argument cannot be accepted here while the
+    ordinary path rejects it.
+    """
+    system = create_constraint_system()
+
+    with pytest.raises(ValueError):
+        system.check_satisfiability({}, timeout_milliseconds=timeout_milliseconds)
+
+
+@pytest.mark.parametrize("timeout_milliseconds", _INVALID_TIMEOUTS)
+def test_check_satisfiability_rejects_invalid_timeout_for_a_hazardous_system(
+    timeout_milliseconds: int,
+) -> None:
+    """Test the bool-coercion early return still validates ``timeout_milliseconds``."""
+    x = mock_identifier("x", 0)
+    system = _build_bool_hazard_system(x)
+
+    with pytest.raises(ValueError):
+        system.check_satisfiability(
+            {x: SymbolType.INT}, timeout_milliseconds=timeout_milliseconds
+        )
+
+
+@pytest.mark.parametrize("timeout_milliseconds", _INVALID_TIMEOUTS)
+def test_check_satisfiability_with_bindings_rejects_invalid_timeout_when_empty(
+    timeout_milliseconds: int,
+) -> None:
+    """Test the empty-system early return validates ``timeout_milliseconds``."""
+    system = create_constraint_system()
+
+    with pytest.raises(ValueError):
+        system.check_satisfiability_with_bindings(
+            {}, {}, timeout_milliseconds=timeout_milliseconds
+        )
+
+
+@pytest.mark.parametrize("timeout_milliseconds", _INVALID_TIMEOUTS)
+def test_check_satisfiability_with_bindings_rejects_invalid_timeout_when_hazardous(
+    timeout_milliseconds: int,
+) -> None:
+    """Test the bool-coercion early return validates ``timeout_milliseconds``."""
+    y = mock_identifier("y", 0)
+    system = create_constraint_system(NotInSetConstraint(y, {1}))
+
+    with pytest.raises(ValueError):
+        system.check_satisfiability_with_bindings(
+            {y: True}, {}, timeout_milliseconds=timeout_milliseconds
+        )
+
+
+@pytest.mark.parametrize(
+    "timeout_milliseconds", [pytest.param(None, id="none"), pytest.param(1, id="one")]
+)
+def test_check_satisfiability_accepts_a_valid_timeout_for_an_empty_system(
+    timeout_milliseconds: int | None,
+) -> None:
+    """Test validation does not disturb the vacuous outcome for accepted values."""
+    system = create_constraint_system()
+
+    outcome = system.check_satisfiability({}, timeout_milliseconds=timeout_milliseconds)
+
+    assert outcome is ConstraintOutcome.SATISFIED

--- a/tests/symbolic/constraint/test_constraint_system.py
+++ b/tests/symbolic/constraint/test_constraint_system.py
@@ -33,6 +33,7 @@ from fhy_core.symbolic.expression import (
     Expression,
     IdentifierExpression,
     LiteralExpression,
+    logical_or,
     make_binary_expression,
 )
 from fhy_core.symbolic.symbol_type import SymbolType
@@ -143,6 +144,49 @@ def test_create_constraint_system_retains_duplicate_constraints() -> None:
     assert len(system.constraints) == 2
 
 
+def test_constraint_system_materializes_a_one_shot_iterator_input() -> None:
+    """Test a one-shot iterator input is retained rather than consumed by validation."""
+    x = mock_identifier("x", 0)
+    first = InSetConstraint(x, {1, 2})
+    second = InSetConstraint(x, {2, 3})
+
+    system = ConstraintSystem(iter([first, second]))  # type: ignore[arg-type]
+
+    assert len(system.constraints) == 2
+
+
+def test_constraint_system_materializes_a_generator_input() -> None:
+    """Test a generator input is retained rather than consumed by validation."""
+    x = mock_identifier("x", 0)
+    members = (InSetConstraint(x, {1, 2}), InSetConstraint(x, {2, 3}))
+
+    system = ConstraintSystem(  # type: ignore[arg-type]
+        member for member in members
+    )
+
+    assert len(system.constraints) == 2
+
+
+@pytest.mark.z3
+def test_constraint_system_from_a_generator_is_not_vacuously_satisfiable() -> None:
+    """Test a generator-built contradictory system is not silently emptied.
+
+    An emptied system answers SATISFIED vacuously, which is the visible
+    symptom of dropping the members: ``x in {1}`` and ``x in {2}`` have no
+    joint witness and must report VIOLATED.
+    """
+    x = mock_identifier("x", 0)
+    members = (InSetConstraint(x, {1}), InSetConstraint(x, {2}))
+
+    system = ConstraintSystem(  # type: ignore[arg-type]
+        member for member in members
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.VIOLATED
+
+
 # =============================================================================
 # Canonical ordering and structural equivalence
 # =============================================================================
@@ -185,15 +229,56 @@ def test_constraint_system_structural_equivalence_false_for_different_members() 
     assert not left.is_structurally_equivalent(right)
 
 
+def test_constraint_system_ordering_is_stable_for_repr_colliding_members() -> None:
+    """Test members whose `repr` forms collide still canonicalize deterministically.
+
+    ``InSetConstraint(x, {"5"})`` and ``InSetConstraint(x, {5})`` are not
+    structurally equivalent (membership is type-strict), so a canonical
+    order keyed on a form that conflates them leaves the two construction
+    orders in different member orders.
+    """
+    x = mock_identifier("x", 0)
+    string_member = InSetConstraint(x, {"5"})
+    integer_member = InSetConstraint(x, {5})
+
+    left = create_constraint_system(string_member, integer_member)
+    right = create_constraint_system(integer_member, string_member)
+
+    assert left.is_structurally_equivalent(right)
+    assert right.is_structurally_equivalent(left)
+
+
+def test_constraint_system_ordering_is_constant_on_equivalent_literal_forms() -> None:
+    """Test pairwise-equivalent members canonicalize into the same order.
+
+    ``LiteralExpression`` treats the integer-grammar string ``"5"`` and the
+    integer ``5`` as structurally equivalent, so two systems whose members
+    are pairwise equivalent must order those members identically and
+    compare equivalent themselves.
+    """
+    n = mock_identifier("n", 0)
+    left = create_constraint_system(
+        EquationConstraint(n, LiteralExpression("5")),
+        EquationConstraint(n, LiteralExpression(4)),
+    )
+    right = create_constraint_system(
+        EquationConstraint(n, LiteralExpression(5)),
+        EquationConstraint(n, LiteralExpression(4)),
+    )
+
+    assert left.is_structurally_equivalent(right)
+    assert right.is_structurally_equivalent(left)
+
+
 def test_constraint_system_canonicalizes_alike_for_independent_identifiers() -> None:
     """Test independently constructed, content-identical systems canonicalize alike.
 
     Two separate ``mock_identifier`` calls with the same name and id are
     distinct ``Mock`` objects, but ``ConstraintSystem`` orders its members
-    by ``repr``. A deterministic, content-based mock ``repr`` is required
-    for two independently built systems over "the same" identifiers, given
-    in different construction order, to canonicalize to the same member
-    order.
+    by a canonical key that reads an identifier through its ``id``. Two
+    independently built systems over "the same" identifiers, given in
+    different construction order, therefore canonicalize to the same
+    member order.
     """
     x1, y1 = mock_identifier("x", 0), mock_identifier("y", 1)
     x2, y2 = mock_identifier("x", 0), mock_identifier("y", 1)
@@ -527,7 +612,7 @@ def test_empty_system_round_trips_through_dict_serialization() -> None:
     assert rebuilt.constraints == ()
 
 
-def test_wire_members_are_emitted_in_repr_sorted_order() -> None:
+def test_wire_members_are_emitted_in_canonical_order() -> None:
     """Test serialized members are emitted in the same order as `constraints`."""
     x = mock_identifier("x", 0)
     y = mock_identifier("y", 1)
@@ -973,6 +1058,91 @@ def test_check_satisfiability_equation_bool_literal_under_bool_sort_is_unaffecte
 
 
 @pytest.mark.z3
+def test_check_satisfiability_non_bool_member_under_bool_sort_is_undecided() -> None:
+    """Test a non-bool member against a `BOOL`-sorted variable is UNDECIDED.
+
+    The coercion hazard is symmetric: ``x in {1}`` with ``x`` typed
+    ``BOOL`` lowers to ``Bool('x') == IntVal(1)``, which Z3 decides by
+    coercing the boolean to an integer. Type-strictly no boolean value
+    satisfies the constraint (``evaluate`` VIOLATES both ``True`` and
+    ``False``), so a decided SATISFIED would be provably wrong.
+    """
+    x = mock_identifier("x", 0)
+    constraint = InSetConstraint(x, {1})
+    system = create_constraint_system(constraint)
+
+    assert constraint.evaluate(True) is ConstraintOutcome.VIOLATED
+    assert constraint.evaluate(False) is ConstraintOutcome.VIOLATED
+
+    outcome = system.check_satisfiability({x: SymbolType.BOOL})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_closed_bool_versus_int_comparison_is_undecided() -> None:
+    """Test a closed bool-against-int comparison is UNDECIDED, not SATISFIED.
+
+    ``True == 1`` has no free identifiers at all, so no symbol type can
+    exempt it. Type-strictly the comparison is false
+    (``evaluate_with_bindings`` VIOLATES it), while Z3 coerces the boolean
+    to the integer ``1`` and would decide it SATISFIED.
+    """
+    x = mock_identifier("x", 0)
+    constraint = EquationConstraint(
+        x,
+        make_binary_expression(
+            BinaryOperation.EQUAL, LiteralExpression(True), LiteralExpression(1)
+        ),
+    )
+    system = create_constraint_system(constraint)
+
+    assert constraint.evaluate_with_bindings({}) is ConstraintOutcome.VIOLATED
+
+    outcome = system.check_satisfiability({})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_bool_value_against_int_member() -> None:
+    """Test a bool binding value against an int set member is UNDECIDED.
+
+    The binding value is lifted into the lowered expression exactly like a
+    set member is, so ``y not in {1}`` under ``{y: True}`` lowers to
+    ``BoolVal(True) != IntVal(1)`` and hits the same coercion. Type-strictly
+    the constraint is SATISFIED (``True`` is not the integer ``1``), so the
+    coerced VIOLATED is provably wrong.
+    """
+    y = mock_identifier("y", 0)
+    system = create_constraint_system(NotInSetConstraint(y, {1}))
+
+    assert system.evaluate_with_bindings({y: True}) is ConstraintOutcome.SATISFIED
+
+    outcome = system.check_satisfiability_with_bindings({y: True}, {})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_bool_value_against_int_membership() -> None:
+    """Test a bool binding value against a permitted int member is UNDECIDED.
+
+    Mirrors the forbidden-set case with the opposite polarity: ``y in {1}``
+    under ``{y: True}`` is type-strictly VIOLATED, while Z3's coercion of
+    ``BoolVal(True)`` to the integer ``1`` would decide it SATISFIED.
+    """
+    y = mock_identifier("y", 0)
+    system = create_constraint_system(InSetConstraint(y, {1}))
+
+    assert system.evaluate_with_bindings({y: True}) is ConstraintOutcome.VIOLATED
+
+    outcome = system.check_satisfiability_with_bindings({y: True}, {})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+@pytest.mark.z3
 def test_check_satisfiability_set_ambiguity_survives_equation_branch() -> None:
     """Test the pre-existing set-constraint bool-ambiguity guard still fires.
 
@@ -992,6 +1162,204 @@ def test_check_satisfiability_set_ambiguity_survives_equation_branch() -> None:
     outcome = system.check_satisfiability({x: SymbolType.INT, y: SymbolType.INT})
 
     assert outcome is ConstraintOutcome.UNDECIDED
+
+
+# =============================================================================
+# Bool sort-hazard precision: soundly lowered bool literals stay decidable
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_check_satisfiability_bool_literal_under_a_logical_operator_is_decided() -> (
+    None
+):
+    """Test a bool literal used as a logical operand does not trigger the guard.
+
+    ``false || x > 5`` lowers the bool literal into ``z3.Or``, which takes
+    boolean operands and performs no integer coercion, so the system stays
+    decidable even though ``x`` is ``INT``-typed.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        EquationConstraint(
+            x,
+            logical_or(
+                LiteralExpression(False),
+                make_binary_expression(BinaryOperation.GREATER, x, 5),
+            ),
+        )
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_sound_bool_literal_does_not_poison_other_members() -> (
+    None
+):
+    """Test a soundly lowered bool literal leaves the rest of the system decidable.
+
+    The hazard is per-site, not per-system: a member whose bool literal is
+    consumed by a logical operator must not degrade an otherwise decidable
+    conjunction to UNDECIDED.
+    """
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    system = create_constraint_system(
+        EquationConstraint(
+            x,
+            logical_or(
+                LiteralExpression(False),
+                make_binary_expression(BinaryOperation.GREATER, x, 5),
+            ),
+        ),
+        InSetConstraint(y, {1, 2}),
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT, y: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_bare_bool_literal_equation_is_decided() -> None:
+    """Test a bare bool literal that is compared against nothing stays decidable.
+
+    ``EquationConstraint(x, LiteralExpression(True))`` lowers to a lone
+    ``BoolVal`` with no coercing operator above it, so no hazard exists
+    even alongside an ``INT``-sorted member constraint on the same variable.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        EquationConstraint(x, LiteralExpression(True)),
+        InSetConstraint(x, {1, 2}),
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_bool_binding_matching_bool_literal() -> (
+    None
+):
+    """Test binding a bool variable to a bool value leaves the residual decidable.
+
+    ``x == True`` under ``{x: True}`` substitutes to ``True == True``,
+    a comparison of two booleans that Z3 lowers without coercion, so the
+    residual is decided rather than degraded to UNDECIDED.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        EquationConstraint(
+            x,
+            make_binary_expression(
+                BinaryOperation.EQUAL, IdentifierExpression(x), LiteralExpression(True)
+            ),
+        )
+    )
+
+    assert system.evaluate_with_bindings({x: True}) is ConstraintOutcome.SATISFIED
+
+    outcome = system.check_satisfiability_with_bindings({x: True}, {})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_piecewise_with_uniform_bool_branches_is_decided() -> None:
+    """Test a piecewise whose branches are all Boolean lowers faithfully.
+
+    ``z3.If`` forces its arms to one sort; arms that already agree need no
+    coercion, so the bool literals in the branches are not a hazard.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        EquationConstraint(
+            x,
+            Expression.piecewise(
+                (
+                    make_binary_expression(BinaryOperation.GREATER, x, 5),
+                    LiteralExpression(True),
+                ),
+                otherwise=LiteralExpression(False),
+            ),
+        )
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.SATISFIED
+
+
+@pytest.mark.z3
+def test_check_satisfiability_piecewise_with_mixed_branches_is_undecided() -> None:
+    """Test a piecewise mixing a Boolean and a numeric branch is UNDECIDED.
+
+    ``z3.If`` coerces the Boolean arm to an integer to match its numeric
+    sibling, which is the same hazard a mixed comparison carries.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(
+        EquationConstraint(
+            x,
+            make_binary_expression(
+                BinaryOperation.EQUAL,
+                IdentifierExpression(x),
+                Expression.piecewise(
+                    (
+                        make_binary_expression(BinaryOperation.GREATER, x, 5),
+                        LiteralExpression(True),
+                    ),
+                    otherwise=LiteralExpression(0),
+                ),
+            ),
+        )
+    )
+
+    outcome = system.check_satisfiability({x: SymbolType.INT})
+
+    assert outcome is ConstraintOutcome.UNDECIDED
+
+
+# =============================================================================
+# Missing symbol types raise ahead of the bool sort-hazard screen (z3-backed)
+# =============================================================================
+
+
+@pytest.mark.z3
+def test_check_satisfiability_missing_symbol_type_raises_despite_bool_hazard() -> None:
+    """Test the missing-symbol-type precondition raises even for a hazardous system.
+
+    Omitting ``symbol_types`` is exactly what makes the sort hazard fire,
+    so the documented ``MissingSymbolTypeError`` must not be downgraded to
+    ``UNDECIDED`` by the screen running first.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {True, 2}))
+
+    with pytest.raises(MissingSymbolTypeError, match=x.name_hint):
+        system.check_satisfiability({})
+
+
+@pytest.mark.z3
+def test_check_satisfiability_with_bindings_missing_symbol_type_raises_on_hazard() -> (
+    None
+):
+    """Test the bindings entry point also raises ahead of the sort-hazard screen.
+
+    Mirrors ``test_check_satisfiability_missing_symbol_type_raises_despite_bool_hazard``
+    for the bindings-aware entry point, with the hazardous identifier left
+    unbound so it survives into the residual.
+    """
+    x = mock_identifier("x", 0)
+    system = create_constraint_system(InSetConstraint(x, {True, 2}))
+
+    with pytest.raises(MissingSymbolTypeError, match=x.name_hint):
+        system.check_satisfiability_with_bindings({}, {})
 
 
 # =============================================================================

--- a/tests/symbolic/constraint/test_constraint_system.py
+++ b/tests/symbolic/constraint/test_constraint_system.py
@@ -1364,11 +1364,10 @@ def test_check_satisfiability_with_bindings_missing_symbol_type_raises_on_hazard
 
 
 # =============================================================================
-# `timeout_milliseconds` passthrough (z3-backed)
+# `timeout_milliseconds` passthrough (solver seam replaced)
 # =============================================================================
 
 
-@pytest.mark.z3
 def test_check_satisfiability_forwards_timeout_milliseconds_to_the_solver_seam(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1398,7 +1397,6 @@ def test_check_satisfiability_forwards_timeout_milliseconds_to_the_solver_seam(
     assert captured["timeout_milliseconds"] == 2500
 
 
-@pytest.mark.z3
 def test_check_satisfiability_with_bindings_forwards_timeout_milliseconds(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1436,7 +1434,6 @@ def test_check_satisfiability_with_bindings_forwards_timeout_milliseconds(
 # =============================================================================
 
 
-@pytest.mark.z3
 def test_check_satisfiability_solver_unknown_result_is_undecided(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1467,7 +1464,6 @@ def test_check_satisfiability_solver_unknown_result_is_undecided(
     assert outcome is ConstraintOutcome.UNDECIDED
 
 
-@pytest.mark.z3
 def test_check_satisfiability_with_bindings_solver_unknown_result_is_undecided(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/symbolic/constraint/test_constraint_system_properties.py
+++ b/tests/symbolic/constraint/test_constraint_system_properties.py
@@ -41,6 +41,7 @@ from .conftest import mock_identifier
 pytestmark = pytest.mark.property
 
 
+@settings(max_examples=50, deadline=None)
 @given(
     x_value=st.integers(min_value=-5, max_value=10),
     y_value=st.integers(min_value=-5, max_value=10),
@@ -72,6 +73,7 @@ def test_evaluate_with_bindings_matches_fold_of_member_outcomes(
 
 
 @pytest.mark.z3
+@settings(max_examples=50, deadline=None)
 @given(threshold=st.integers(min_value=0, max_value=10))
 def test_check_satisfiability_matches_brute_force_enumeration(threshold: int) -> None:
     """Test z3-backed satisfiability agrees with brute-force enumeration."""

--- a/tests/symbolic/constraint/test_constraint_system_properties.py
+++ b/tests/symbolic/constraint/test_constraint_system_properties.py
@@ -1,0 +1,87 @@
+"""Hypothesis property tests for `ConstraintSystem`.
+
+Kept in a dedicated module so a test environment without hypothesis
+installed (the CI `tests` lane syncs only the `test` dependency group)
+can still collect this package cleanly: the `pytest.importorskip` below
+skips the whole module before the `hypothesis` import is attempted.
+"""
+
+import pytest
+
+pytest.importorskip("hypothesis")
+from hypothesis import given
+from hypothesis import strategies as st
+
+from fhy_core.symbolic.constraint import (
+    Constraint,
+    ConstraintOutcome,
+    EquationConstraint,
+    InSetConstraint,
+    create_constraint_system,
+)
+from fhy_core.symbolic.expression import BinaryOperation, make_binary_expression
+from fhy_core.symbolic.symbol_type import SymbolType
+
+from .conftest import mock_identifier
+
+pytestmark = pytest.mark.property
+
+
+@given(
+    x_value=st.integers(min_value=-5, max_value=10),
+    y_value=st.integers(min_value=-5, max_value=10),
+)
+def test_evaluate_with_bindings_matches_fold_of_member_outcomes(
+    x_value: int, y_value: int
+) -> None:
+    """Test the conjunction outcome matches folding each member's own outcome."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    members: tuple[Constraint, ...] = (
+        InSetConstraint(x, {1, 2, 3, 4}),
+        InSetConstraint(y, {0, 1, 2}),
+        EquationConstraint(x, make_binary_expression(BinaryOperation.LESS, x, y)),
+    )
+    system = create_constraint_system(*members)
+    bindings = {x: x_value, y: y_value}
+
+    outcome = system.evaluate_with_bindings(bindings)
+
+    member_outcomes = [member.evaluate_with_bindings(bindings) for member in members]
+    if any(o is ConstraintOutcome.VIOLATED for o in member_outcomes):
+        expected = ConstraintOutcome.VIOLATED
+    elif all(o is ConstraintOutcome.SATISFIED for o in member_outcomes):
+        expected = ConstraintOutcome.SATISFIED
+    else:
+        expected = ConstraintOutcome.UNDECIDED
+    assert outcome is expected
+
+
+@pytest.mark.z3
+@given(threshold=st.integers(min_value=0, max_value=10))
+def test_check_satisfiability_matches_brute_force_enumeration(threshold: int) -> None:
+    """Test z3-backed satisfiability agrees with brute-force enumeration."""
+    x = mock_identifier("x", 0)
+    y = mock_identifier("y", 1)
+    domain = tuple(range(6))
+    link_expression = make_binary_expression(
+        BinaryOperation.EQUAL,
+        make_binary_expression(BinaryOperation.ADD, x, threshold),
+        y,
+    )
+    system = create_constraint_system(
+        InSetConstraint(x, set(domain)),
+        InSetConstraint(y, set(domain)),
+        EquationConstraint(x, link_expression),
+    )
+
+    brute_force_satisfiable = any(a + threshold == b for a in domain for b in domain)
+
+    outcome = system.check_satisfiability({x: SymbolType.INT, y: SymbolType.INT})
+
+    expected = (
+        ConstraintOutcome.SATISFIED
+        if brute_force_satisfiable
+        else ConstraintOutcome.VIOLATED
+    )
+    assert outcome is expected

--- a/tests/symbolic/constraint/test_constraint_system_properties.py
+++ b/tests/symbolic/constraint/test_constraint_system_properties.py
@@ -6,20 +6,34 @@ can still collect this package cleanly: the `pytest.importorskip` below
 skips the whole module before the `hypothesis` import is attempted.
 """
 
+from typing import Any
+
 import pytest
 
 pytest.importorskip("hypothesis")
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from fhy_core.symbolic.constraint import (
     Constraint,
+    ConstraintMember,
     ConstraintOutcome,
     EquationConstraint,
     InSetConstraint,
+    NotInSetConstraint,
+    # The canonical ordering key is private to the constraint module. The
+    # property below is the invariant that makes `ConstraintSystem`'s member
+    # order well defined, so it is asserted against the key itself.
+    _build_constraint_ordering_key,
     create_constraint_system,
 )
-from fhy_core.symbolic.expression import BinaryOperation, make_binary_expression
+from fhy_core.symbolic.expression import (
+    BinaryOperation,
+    Expression,
+    LiteralExpression,
+    LiteralType,
+    make_binary_expression,
+)
 from fhy_core.symbolic.symbol_type import SymbolType
 
 from .conftest import mock_identifier
@@ -85,3 +99,95 @@ def test_check_satisfiability_matches_brute_force_enumeration(threshold: int) ->
         else ConstraintOutcome.VIOLATED
     )
     assert outcome is expected
+
+
+# =============================================================================
+# Canonical ordering key is constant on structural-equivalence classes
+# =============================================================================
+
+_VARIABLE_IDS = (0, 1)
+
+# Weak literal-equivalence classes: every form within a tuple builds a
+# `LiteralExpression` structurally equivalent to every other form in the same
+# tuple. ``5``/``"5"``/``"05"`` share the integer bucket, ``"1.5"``/``"1.50"``
+# the exact-decimal bucket, and ``0.0``/``-0.0`` the binary-float bucket.
+_LITERAL_EQUIVALENCE_CLASSES: tuple[tuple[LiteralType, ...], ...] = (
+    (5, "5", "05"),
+    (4, "4", "0004"),
+    ("1.5", "1.50", "1.500"),
+    (1.5,),
+    (0.0, -0.0),
+    (True,),
+    (False,),
+)
+
+# Members chosen so the type-strict classes are adjacent: ``1``, ``"1"``,
+# ``1.0``, and ``True`` are four distinct members, not one.
+_MEMBER_FORMS: tuple[ConstraintMember, ...] = (
+    1,
+    "1",
+    1.0,
+    True,
+    2,
+    (1, 2),
+    frozenset({1}),
+)
+
+_SET_KINDS = (InSetConstraint, NotInSetConstraint)
+
+
+def _build_literal_equation(
+    variable: Any, form: LiteralType, wrap_in_comparison: bool
+) -> Constraint:
+    expression: Expression = LiteralExpression(form)
+    if wrap_in_comparison:
+        expression = make_binary_expression(BinaryOperation.EQUAL, variable, expression)
+    return EquationConstraint(variable, expression)
+
+
+@st.composite
+def _draw_constraint_pair(draw: Any) -> tuple[Constraint, Constraint]:
+    """Draw two constraints of one shape, built from independently chosen forms.
+
+    Both sides get their own ``mock_identifier`` for the drawn id, so the
+    pair also exercises identifier keying by ``id`` rather than by object
+    identity. The equation branch varies the literal form within one weak
+    equivalence class; the set branch varies member order.
+    """
+    variable_id = draw(st.sampled_from(_VARIABLE_IDS))
+    left_variable = mock_identifier("v", variable_id)
+    right_variable = mock_identifier("v", variable_id)
+    kind_index = draw(st.integers(min_value=0, max_value=2))
+    if kind_index == 0:
+        forms = draw(st.sampled_from(_LITERAL_EQUIVALENCE_CLASSES))
+        wrap_in_comparison = draw(st.booleans())
+        return (
+            _build_literal_equation(
+                left_variable, draw(st.sampled_from(forms)), wrap_in_comparison
+            ),
+            _build_literal_equation(
+                right_variable, draw(st.sampled_from(forms)), wrap_in_comparison
+            ),
+        )
+    kind = _SET_KINDS[kind_index - 1]
+    members = draw(st.lists(st.sampled_from(_MEMBER_FORMS), min_size=0, max_size=3))
+    shuffled = draw(st.permutations(members))
+    return kind(left_variable, members), kind(right_variable, shuffled)
+
+
+@settings(max_examples=50, deadline=None)
+@given(pair=_draw_constraint_pair())
+def test_ordering_key_is_constant_on_structural_equivalence_classes(
+    pair: tuple[Constraint, Constraint],
+) -> None:
+    """Test the canonical ordering key agrees on structurally equivalent members.
+
+    This is the invariant that makes ``ConstraintSystem``'s canonical
+    member order well defined: sorting by a key that separates two
+    equivalent members would leave two equivalent systems in different
+    member orders, and hence not equivalent themselves.
+    """
+    left, right = pair
+    if not left.is_structurally_equivalent(right):
+        return
+    assert _build_constraint_ordering_key(left) == _build_constraint_ordering_key(right)

--- a/tests/symbolic/constraint/test_error_registration.py
+++ b/tests/symbolic/constraint/test_error_registration.py
@@ -1,8 +1,14 @@
-"""Tests covering `ConstraintError` identity."""
+"""Tests covering `ConstraintError` and `MissingSymbolTypeError` identity."""
 
-from fhy_core.symbolic.constraint import ConstraintError
+from fhy_core.symbolic.constraint import ConstraintError, MissingSymbolTypeError
 
 
 def test_constraint_error_is_value_error_subclass() -> None:
-    """Test `ConstraintError` remains a `ValueError` for backward compatibility."""
+    """Test `ConstraintError` is a `ValueError` subclass."""
     assert issubclass(ConstraintError, ValueError)
+
+
+def test_missing_symbol_type_error_is_value_error_subclass() -> None:
+    """Test `MissingSymbolTypeError` is a `ValueError` subclass, not `KeyError`."""
+    assert issubclass(MissingSymbolTypeError, ValueError)
+    assert not issubclass(MissingSymbolTypeError, KeyError)

--- a/tests/symbolic/constraint/test_serialization.py
+++ b/tests/symbolic/constraint/test_serialization.py
@@ -8,6 +8,7 @@ import pytest
 from fhy_core.serialization import (
     DeserializationDictStructureError,
     DeserializationValueError,
+    SerializationFormat,
     SerializedDict,
 )
 from fhy_core.symbolic.constraint import (
@@ -22,7 +23,12 @@ from fhy_core.symbolic.expression import (
     make_binary_expression,
 )
 
-from .conftest import SET_KINDS, SerializableEqualHashable, mock_identifier
+from .conftest import (
+    SET_KINDS,
+    HashCollidingMember,
+    SerializableEqualHashable,
+    mock_identifier,
+)
 
 SetConstraintType = type[Constraint]
 
@@ -143,14 +149,53 @@ def test_set_constraint_serialization_keeps_bool_int_and_float_distinct(
     assert len(serialized) == 3
 
 
-def test_in_set_constraint_serialized_values_are_repr_sorted() -> None:
-    """Test serialized members are emitted in repr-sorted order for determinism."""
-    constraint = InSetConstraint(mock_identifier("x", 0), {3, 1, 2})
-
+def _read_wire_members(constraint: Constraint, field: str) -> list[Any]:
+    """Return the serialized member list a set constraint puts on the wire."""
     payload_data = cast(dict[str, Any], constraint.serialize_to_dict()["__data__"])
-    serialized_values: list[Any] = payload_data["valid_values"]
+    members: list[Any] = payload_data[field]
+    return members
 
+
+@pytest.mark.parametrize("factory, field", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_serialized_values_are_repr_sorted(
+    factory: SetConstraintType, field: str
+) -> None:
+    """Test serialized members are emitted in repr-sorted order for determinism.
+
+    The members are chosen so repr-sorted order (``10, 2, 33, 4`` --
+    lexicographic on the rendered digits) is not the numeric order and is
+    not the order the normalized member set iterates in, so emitting the
+    set as it happens to iterate would produce a different list.
+    """
+    constraint = factory(mock_identifier("x", 0), {10, 2, 33, 4})  # type: ignore[call-arg]
+
+    serialized_values = _read_wire_members(constraint, field)
+
+    assert [member["__data__"] for member in serialized_values] == [10, 2, 33, 4]
     assert serialized_values == sorted(serialized_values, key=repr)
+
+
+@pytest.mark.parametrize("factory, field", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_wire_order_is_independent_of_construction_order(
+    factory: SetConstraintType, field: str
+) -> None:
+    """Test two constraints over the same members serialize to one byte-identical list.
+
+    The members collide on hash, so the two constraints provably store
+    them in different orders. Determinism of the wire form therefore has
+    to come from sorting at encode time rather than from the stored order
+    happening to agree.
+    """
+    x = mock_identifier("x", 0)
+    members = [HashCollidingMember(1), HashCollidingMember(2)]
+    left = factory(x, list(members))  # type: ignore[call-arg]
+    right = factory(x, list(reversed(members)))  # type: ignore[call-arg]
+
+    assert getattr(left, field) != getattr(right, field), (
+        "the two constraints must store their members in different orders "
+        "for this test to say anything about encode-time ordering"
+    )
+    assert _read_wire_members(left, field) == _read_wire_members(right, field)
 
 
 # =============================================================================
@@ -310,3 +355,24 @@ def test_set_member_deserializer_rejects_none_after_deserialization(
 
     with pytest.raises((DeserializationValueError, ValueError)):
         factory.deserialize_data_from_dict(bad_payload)
+
+
+@pytest.mark.parametrize("factory, field", _SET_KINDS_WITH_FIELD)
+@pytest.mark.parametrize("fmt", list(SerializationFormat))
+def test_set_constraint_round_trips_through_every_format(
+    factory: SetConstraintType, field: str, fmt: SerializationFormat
+) -> None:
+    """Test a set constraint round-trips through DICT, JSON, and BINARY.
+
+    The type-strict member set is derived from the public member field
+    rather than carried on the wire, so a restored constraint has to
+    re-derive it and decide exactly as the original does.
+    """
+    constraint = factory(mock_identifier("x", 0), {1, 2, 3})  # type: ignore[call-arg]
+
+    payload = constraint.serialize(fmt)
+    restored = type(constraint).deserialize(payload, fmt)
+
+    assert set(getattr(restored, field)) == {1, 2, 3}
+    for probe in (1, 2, 3, 99):
+        assert restored.is_satisfied(probe) == constraint.is_satisfied(probe)

--- a/tests/symbolic/constraint/test_set_constraints.py
+++ b/tests/symbolic/constraint/test_set_constraints.py
@@ -167,6 +167,24 @@ def test_set_constraint_repr_includes_variable(
     assert repr(x) in rendered
 
 
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_repr_distinguishes_string_from_numeric_members(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test ``repr`` renders a ``str`` member distinguishably from an ``int`` member.
+
+    Membership is type-strict, so ``{"5"}`` and ``{5}`` are different
+    constraints; rendering both members bare would make the two textual
+    forms indistinguishable.
+    """
+    x = mock_identifier("x", 0)
+
+    string_member = repr(factory(x, {"5"}))
+    integer_member = repr(factory(x, {5}))
+
+    assert string_member != integer_member
+
+
 @pytest.mark.parametrize("factory, str_marker", _KINDS_WITH_STR_MARKER)
 def test_set_constraint_str_renders_membership_marker(
     factory: SetConstraintFactory,

--- a/tests/symbolic/constraint/test_set_constraints.py
+++ b/tests/symbolic/constraint/test_set_constraints.py
@@ -348,3 +348,64 @@ def test_set_constraint_rejects_bare_string_like_members(
     """Test a bare str/bytes/bytearray is rejected, not split into elements."""
     with pytest.raises(ConstraintError):
         factory(mock_identifier("x", 0), members)
+
+
+# =============================================================================
+# Public field encapsulation (`valid_values` / `invalid_values`)
+# =============================================================================
+
+_SET_KINDS_WITH_FIELD = [
+    pytest.param(InSetConstraint, "valid_values", id="in_set"),
+    pytest.param(NotInSetConstraint, "invalid_values", id="not_in_set"),
+]
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_public_field_holds_the_raw_members(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test the constructor-keyword field holds the raw member values."""
+    constraint = factory(mock_identifier("x", 0), {1, 2})
+
+    assert set(getattr(constraint, field_name)) == {1, 2}
+
+
+# Regression guard for a field that used to store the internal type-strict
+# wrapper directly: reading it gave a silently wrong membership answer
+# (`1 in constraint.valid_values` was `False` for an actual member `1`,
+# because the wrapper's `__eq__`/`__hash__` never matched a raw `1`). Direct
+# membership on the field reflects the constructed member set regardless of
+# in-set/not-in-set polarity; `is_satisfied` (exercised elsewhere) is what
+# differs by kind.
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_public_field_direct_membership_reflects_true_membership(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test membership on the public field matches what was constructed."""
+    constraint = factory(mock_identifier("x", 0), {1, 2})
+
+    assert 1 in getattr(constraint, field_name)
+    assert 2 in getattr(constraint, field_name)
+    assert 99 not in getattr(constraint, field_name)
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_public_field_never_yields_internal_wrapper_type(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test every element of the public field is a plain member type, not a wrapper."""
+    constraint = factory(mock_identifier("x", 0), {1, 2})
+
+    for member in getattr(constraint, field_name):
+        assert type(member) in (int, float, str, bool)
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_public_field_matches_members_property(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test the public field and the `members` property agree on content."""
+    constraint = factory(mock_identifier("x", 0), {1, 2, 3})
+    assert isinstance(constraint, (InSetConstraint, NotInSetConstraint))
+
+    assert set(getattr(constraint, field_name)) == set(constraint.members)

--- a/tests/symbolic/constraint/test_set_constraints.py
+++ b/tests/symbolic/constraint/test_set_constraints.py
@@ -5,11 +5,16 @@ delegation, ``variable`` property, repr/str rendering, member shapes),
 so the tests are parametrized over the constraint factory.
 """
 
+import copy
+import dataclasses
+import io
+import pickle
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
+import fhy_core.symbolic.constraint as constraint_module
 from fhy_core.identifier import Identifier
 from fhy_core.symbolic.constraint import (
     Constraint,
@@ -18,6 +23,8 @@ from fhy_core.symbolic.constraint import (
     InSetConstraint,
     NotInSetConstraint,
 )
+from fhy_core.traits import FrozenMutationError
+from fhy_core.utils.override import override
 
 from .conftest import SET_KINDS, SerializableEqualHashable, mock_identifier
 
@@ -427,3 +434,227 @@ def test_set_constraint_public_field_matches_members_property(
     assert isinstance(constraint, (InSetConstraint, NotInSetConstraint))
 
     assert set(getattr(constraint, field_name)) == set(constraint.members)
+
+
+# =============================================================================
+# Type-strict member-set storage
+# =============================================================================
+
+_MEMBERS = (1, 2, 3)
+"""Members shared by the member-set storage tests."""
+
+_ABSENT_PROBE = 99
+"""Value deliberately outside `_MEMBERS`, used to probe the negative outcome."""
+
+_READERS: list[Any] = [
+    pytest.param(lambda constraint: constraint.evaluate(1), id="evaluate"),
+    pytest.param(lambda constraint: constraint.is_satisfied(1), id="is_satisfied"),
+    pytest.param(
+        lambda constraint: constraint.convert_to_expression(),
+        id="convert_to_expression",
+    ),
+    pytest.param(repr, id="repr"),
+    pytest.param(str, id="str"),
+]
+"""Every reader of the type-strict member set, as a single-argument callable."""
+
+
+class _IdentifierByReferencePickler(pickle.Pickler):
+    """Pickler that emits identifiers as external references.
+
+    A test constraint's variable is a ``Mock(spec=Identifier)``, which
+    pickle refuses to serialize. Handing every identifier to the pickler
+    as a persistent reference keeps the constraint itself -- including
+    whatever derived state it stores alongside its fields -- on the real
+    ``dumps``/``loads`` path.
+    """
+
+    referenced: dict[str, Identifier]
+
+    def __init__(self, file: Any, referenced: dict[str, Identifier]) -> None:
+        super().__init__(file)
+        self.referenced = referenced
+
+    @override
+    def persistent_id(self, obj: Any) -> str | None:
+        if isinstance(obj, Identifier):
+            key = str(id(obj))
+            self.referenced[key] = obj
+            return key
+        return None
+
+
+class _IdentifierByReferenceUnpickler(pickle.Unpickler):
+    """Unpickler resolving the external identifier references by key."""
+
+    referenced: dict[str, Identifier]
+
+    def __init__(self, file: Any, referenced: dict[str, Identifier]) -> None:
+        super().__init__(file)
+        self.referenced = referenced
+
+    @override
+    def persistent_load(self, pid: Any) -> Identifier:
+        return self.referenced[pid]
+
+
+def _round_trip_through_pickle(constraint: Constraint) -> Constraint:
+    """Return the constraint after a ``pickle.dumps``/``loads`` round trip."""
+    referenced: dict[str, Identifier] = {}
+    buffer = io.BytesIO()
+    _IdentifierByReferencePickler(buffer, referenced).dump(constraint)
+    buffer.seek(0)
+    restored = _IdentifierByReferenceUnpickler(buffer, referenced).load()
+    assert isinstance(restored, Constraint)
+    return restored
+
+
+def _assert_membership_agrees_with_public_field(
+    constraint: Constraint, field_name: str
+) -> None:
+    """Assert the constraint decides exactly as a fresh one over its public field.
+
+    The type-strict member set is derived state; the public
+    ``valid_values``/``invalid_values`` tuple is the source of truth. Any
+    drift between the two shows up as a disagreement with a constraint
+    built from that tuple alone.
+    """
+    public_members = tuple(getattr(constraint, field_name))
+    reference = type(constraint)(constraint.variable, public_members)  # type: ignore[call-arg]
+
+    for probe in (*public_members, _ABSENT_PROBE):
+        assert constraint.evaluate(probe) is reference.evaluate(probe), (
+            f"member set disagrees with {field_name} for probe {probe!r}"
+        )
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize("read", _READERS)
+def test_set_constraint_reader_does_not_rebuild_the_type_strict_member_set(
+    monkeypatch: pytest.MonkeyPatch,
+    factory: SetConstraintFactory,
+    read: Callable[[Constraint], object],
+) -> None:
+    """Test no reader re-derives the type-strict member set from the raw field.
+
+    The set is built once during construction. Re-deriving it on every
+    read turns a constant-time membership check into a full rebuild --
+    one wrapper allocation and one hash per stored member, per call --
+    and ``__repr__`` additionally feeds the ``ConstraintSystem`` ordering
+    key, so the cost multiplies across a system.
+    """
+    constraint = factory(mock_identifier("x", 0), _MEMBERS)
+    rebuild_count = 0
+    build_member_set = constraint_module._wrap_member_collection
+
+    def counting_build_member_set(values: Any) -> Any:
+        nonlocal rebuild_count
+        rebuild_count += 1
+        return build_member_set(values)
+
+    monkeypatch.setattr(
+        constraint_module, "_wrap_member_collection", counting_build_member_set
+    )
+
+    read(constraint)
+
+    assert rebuild_count == 0
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_pickle_round_trip_preserves_evaluation(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test a pickled-and-restored set constraint still evaluates correctly."""
+    constraint = factory(mock_identifier("x", 0), _MEMBERS)
+
+    restored = _round_trip_through_pickle(constraint)
+
+    assert tuple(getattr(restored, field_name)) == tuple(
+        getattr(constraint, field_name)
+    )
+    _assert_membership_agrees_with_public_field(restored, field_name)
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+@pytest.mark.parametrize(
+    "duplicate",
+    [pytest.param(copy.copy, id="copy"), pytest.param(copy.deepcopy, id="deepcopy")],
+)
+def test_set_constraint_copy_preserves_evaluation(
+    factory: SetConstraintFactory,
+    field_name: str,
+    duplicate: Callable[[Constraint], Constraint],
+) -> None:
+    """Test shallow and deep copies still evaluate against their own member set."""
+    constraint = factory(mock_identifier("x", 0), _MEMBERS)
+
+    duplicated = duplicate(constraint)
+
+    assert tuple(getattr(duplicated, field_name)) == tuple(
+        getattr(constraint, field_name)
+    )
+    _assert_membership_agrees_with_public_field(duplicated, field_name)
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_replace_rederives_the_member_set_from_the_new_values(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test ``dataclasses.replace`` decides against the replacement members.
+
+    The derived member set must not survive from the source instance; a
+    stale set would keep answering for the members that were replaced.
+    """
+    constraint = factory(mock_identifier("x", 0), _MEMBERS)
+
+    replaced = cast(
+        Constraint, dataclasses.replace(cast(Any, constraint), **{field_name: (7, 8)})
+    )
+
+    assert set(getattr(replaced, field_name)) == {7, 8}
+    _assert_membership_agrees_with_public_field(replaced, field_name)
+    assert replaced.evaluate(7) is not replaced.evaluate(_ABSENT_PROBE)
+    assert replaced.evaluate(1) is replaced.evaluate(_ABSENT_PROBE)
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_member_set_cannot_drift_from_the_public_field(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test the public field stays the sole source of truth for membership.
+
+    Neither the public field nor the derived member set is writable, so
+    the two cannot be driven apart after construction.
+    """
+    constraint = factory(mock_identifier("x", 0), _MEMBERS)
+
+    with pytest.raises(FrozenMutationError):
+        setattr(constraint, field_name, (7, 8))
+    with pytest.raises(FrozenMutationError):
+        cast(Any, constraint)._members = frozenset()
+
+    _assert_membership_agrees_with_public_field(constraint, field_name)
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize(
+    "duplicate",
+    [
+        pytest.param(_round_trip_through_pickle, id="pickle"),
+        pytest.param(copy.copy, id="copy"),
+        pytest.param(copy.deepcopy, id="deepcopy"),
+    ],
+)
+def test_set_constraint_equivalence_survives_duplication(
+    factory: SetConstraintFactory,
+    duplicate: Callable[[Constraint], Constraint],
+) -> None:
+    """Test structural and alpha equivalence hold between a constraint and its copy."""
+    constraint = factory(mock_identifier("x", 0), _MEMBERS)
+
+    duplicated = duplicate(constraint)
+
+    assert constraint.is_structurally_equivalent(duplicated)
+    assert duplicated.is_structurally_equivalent(constraint)
+    assert constraint.is_alpha_equivalent(duplicated)

--- a/tests/symbolic/constraint/test_set_constraints.py
+++ b/tests/symbolic/constraint/test_set_constraints.py
@@ -26,7 +26,12 @@ from fhy_core.symbolic.constraint import (
 from fhy_core.traits import FrozenMutationError
 from fhy_core.utils.override import override
 
-from .conftest import SET_KINDS, SerializableEqualHashable, mock_identifier
+from .conftest import (
+    SET_KINDS,
+    HashCollidingMember,
+    SerializableEqualHashable,
+    mock_identifier,
+)
 
 SetConstraintFactory = Callable[[Identifier, Any], Constraint]
 
@@ -434,6 +439,33 @@ def test_set_constraint_public_field_matches_members_property(
     assert isinstance(constraint, (InSetConstraint, NotInSetConstraint))
 
     assert set(getattr(constraint, field_name)) == set(constraint.members)
+
+
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
+def test_set_constraint_members_order_is_independent_of_construction_order(
+    factory: SetConstraintFactory, field_name: str
+) -> None:
+    """Test `members` orders alike for two constraints built in opposite orders.
+
+    Normalization stores members in `frozenset` iteration order, which
+    depends on insertion order once members collide on hash (and, for
+    `str` members, on the per-process hash seed). The members here
+    collide, so the two constraints provably store them in different
+    orders and the accessor has to impose the ordering itself rather
+    than inherit one that happens to agree.
+    """
+    x = mock_identifier("x", 0)
+    members = [HashCollidingMember(1), HashCollidingMember(2)]
+    left = factory(x, list(members))
+    right = factory(x, list(reversed(members)))
+    assert isinstance(left, (InSetConstraint, NotInSetConstraint))
+    assert isinstance(right, (InSetConstraint, NotInSetConstraint))
+
+    assert getattr(left, field_name) != getattr(right, field_name), (
+        "the two constraints must store their members in different orders "
+        "for this test to say anything about the accessor's ordering"
+    )
+    assert left.members == right.members
 
 
 # =============================================================================

--- a/tests/symbolic/constraint/test_structural_equivalence.py
+++ b/tests/symbolic/constraint/test_structural_equivalence.py
@@ -121,6 +121,36 @@ def test_set_constraint_inequivalent_for_strict_subset_values(
 
 
 # =============================================================================
+# Alpha equivalence (set-kind member-collection comparisons)
+# =============================================================================
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_alpha_equivalence_matches_structural_for_same_variable(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test alpha equivalence agrees with structural equivalence for one variable."""
+    x = mock_identifier("x", 0)
+    left = factory(x, [1, 2])
+    right = factory(x, [2, 1])
+
+    assert left.is_alpha_equivalent(right) == left.is_structurally_equivalent(right)
+    assert left.is_alpha_equivalent(right) is True
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+def test_set_constraint_alpha_inequivalent_for_different_values(
+    factory: SetConstraintFactory,
+) -> None:
+    """Test alpha equivalence is `False` when the member sets differ."""
+    x = mock_identifier("x", 0)
+    left = factory(x, {1, 2})
+    right = factory(x, {1, 3})
+
+    assert not left.is_alpha_equivalent(right)
+
+
+# =============================================================================
 # Cross-kind / non-Constraint comparisons
 # =============================================================================
 

--- a/tests/symbolic/constraint/test_structural_equivalence.py
+++ b/tests/symbolic/constraint/test_structural_equivalence.py
@@ -12,6 +12,7 @@ from fhy_core.symbolic.constraint import (
     ConstraintOutcome,
     EquationConstraint,
     InSetConstraint,
+    NotInSetConstraint,
 )
 from fhy_core.symbolic.expression import Expression, LiteralExpression
 from fhy_core.term.derived_equivalence import EquivalenceDerivationError
@@ -21,6 +22,7 @@ from fhy_core.utils.override import override
 from .conftest import (
     ALL_KINDS,
     SET_KINDS,
+    HashCollidingMember,
     build_equation_constraint,
     build_in_set_constraint,
     build_not_in_set_constraint,
@@ -29,6 +31,12 @@ from .conftest import (
 
 ConstraintFactory = Callable[[Identifier], Constraint]
 SetConstraintFactory = Callable[[Identifier, Any], Constraint]
+
+_SET_KINDS_WITH_FIELD = [
+    pytest.param(InSetConstraint, "valid_values", id="in_set"),
+    pytest.param(NotInSetConstraint, "invalid_values", id="not_in_set"),
+]
+"""Parametrize list pairing each set-constraint kind with its member field."""
 
 
 # =============================================================================
@@ -95,16 +103,28 @@ def test_set_constraint_inequivalent_for_different_values(
     assert not left.is_structurally_equivalent(right)
 
 
-@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
 def test_set_constraint_uses_value_equality_not_identity(
-    factory: SetConstraintFactory,
+    factory: SetConstraintFactory, field_name: str
 ) -> None:
-    """Test independent collections with equal contents are equivalent."""
-    x = mock_identifier("x", 0)
-    left = factory(x, [1, 2])
-    right = factory(x, [2, 1])
+    """Test independent collections with equal contents are equivalent.
 
+    The two constraints are built from the same members in opposite
+    orders and store them in genuinely different orders, so equivalence
+    has to normalize rather than lean on the stored tuples comparing
+    equal by accident.
+    """
+    x = mock_identifier("x", 0)
+    members = [HashCollidingMember(1), HashCollidingMember(2)]
+    left = factory(x, list(members))
+    right = factory(x, list(reversed(members)))
+
+    assert getattr(left, field_name) != getattr(right, field_name), (
+        "the two constraints must store their members in different orders "
+        "for this test to say anything about order independence"
+    )
     assert left.is_structurally_equivalent(right)
+    assert right.is_structurally_equivalent(left)
 
 
 @pytest.mark.parametrize("factory", SET_KINDS)
@@ -125,15 +145,25 @@ def test_set_constraint_inequivalent_for_strict_subset_values(
 # =============================================================================
 
 
-@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize("factory, field_name", _SET_KINDS_WITH_FIELD)
 def test_set_constraint_alpha_equivalence_matches_structural_for_same_variable(
-    factory: SetConstraintFactory,
+    factory: SetConstraintFactory, field_name: str
 ) -> None:
-    """Test alpha equivalence agrees with structural equivalence for one variable."""
-    x = mock_identifier("x", 0)
-    left = factory(x, [1, 2])
-    right = factory(x, [2, 1])
+    """Test alpha equivalence agrees with structural equivalence for one variable.
 
+    As for the structural case, the two constraints genuinely store their
+    members in different orders, so the agreement is not an artifact of
+    the stored tuples being identical.
+    """
+    x = mock_identifier("x", 0)
+    members = [HashCollidingMember(1), HashCollidingMember(2)]
+    left = factory(x, list(members))
+    right = factory(x, list(reversed(members)))
+
+    assert getattr(left, field_name) != getattr(right, field_name), (
+        "the two constraints must store their members in different orders "
+        "for this test to say anything about order independence"
+    )
     assert left.is_alpha_equivalent(right) == left.is_structurally_equivalent(right)
     assert left.is_alpha_equivalent(right) is True
 
@@ -148,6 +178,77 @@ def test_set_constraint_alpha_inequivalent_for_different_values(
     right = factory(x, {1, 3})
 
     assert not left.is_alpha_equivalent(right)
+
+
+# =============================================================================
+# Type-strict member comparison
+# =============================================================================
+
+_TYPE_STRICT_MEMBER_PAIRS = [
+    pytest.param([1], [True], id="int_vs_bool"),
+    pytest.param([1], [1.0], id="int_vs_float"),
+]
+"""Member pairs that plain ``==`` on the stored tuples cannot tell apart.
+
+``(1,) == (True,)`` and ``(1,) == (1.0,)`` are both ``True`` in Python,
+yet membership is type-strict: ``InSetConstraint(x, [1]).evaluate(True)``
+reports ``VIOLATED``. Equivalence has to agree with evaluation, so the
+member field is compared through the type-strict normalizer rather than
+by the stored tuples' own equality.
+"""
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize("left_members, right_members", _TYPE_STRICT_MEMBER_PAIRS)
+def test_set_constraint_inequivalent_for_members_differing_only_in_type(
+    factory: SetConstraintFactory,
+    left_members: list[Any],
+    right_members: list[Any],
+) -> None:
+    """Test members that are ``==``-equal but differently typed are inequivalent."""
+    x = mock_identifier("x", 0)
+    left = factory(x, left_members)
+    right = factory(x, right_members)
+
+    assert not left.is_structurally_equivalent(right)
+    assert not right.is_structurally_equivalent(left)
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize("left_members, right_members", _TYPE_STRICT_MEMBER_PAIRS)
+def test_set_constraint_alpha_inequivalent_for_members_differing_only_in_type(
+    factory: SetConstraintFactory,
+    left_members: list[Any],
+    right_members: list[Any],
+) -> None:
+    """Test alpha equivalence is also type-strict about member types."""
+    x = mock_identifier("x", 0)
+    left = factory(x, left_members)
+    right = factory(x, right_members)
+
+    assert not left.is_alpha_equivalent(right)
+    assert not right.is_alpha_equivalent(left)
+
+
+@pytest.mark.parametrize("factory", SET_KINDS)
+@pytest.mark.parametrize("left_members, right_members", _TYPE_STRICT_MEMBER_PAIRS)
+def test_set_constraint_equivalence_agrees_with_evaluation_on_member_types(
+    factory: SetConstraintFactory,
+    left_members: list[Any],
+    right_members: list[Any],
+) -> None:
+    """Test two constraints called equivalent never disagree on a member probe.
+
+    This is the invariant the type-strict comparison exists to protect:
+    were the two treated as equivalent, one would report the other's
+    member as a member and the other would not.
+    """
+    x = mock_identifier("x", 0)
+    left = factory(x, left_members)
+    right = factory(x, right_members)
+
+    assert left.evaluate(right_members[0]) is not left.evaluate(left_members[0])
+    assert not left.is_structurally_equivalent(right)
 
 
 # =============================================================================

--- a/tests/symbolic/expression/passes/test_z3_pass.py
+++ b/tests/symbolic/expression/passes/test_z3_pass.py
@@ -807,3 +807,72 @@ def test_convert_call_expression_to_z3_rejects_unresolved_call() -> None:
 
     with pytest.raises(PassExecutionError, match="TypeError"):
         convert_expression_to_z3_expression(expression, {})
+
+
+# =============================================================================
+# Third-party characterization: Z3's Boolean-to-integer coercion
+# =============================================================================
+#
+# The two tests below characterize the Z3 Python bindings themselves, not this
+# package. `fhy_core.symbolic.constraint`'s bool sort-hazard screen exists only
+# because Z3 silently coerces a Boolean operand in a numeric context instead of
+# refusing the mixed-sort expression. Nothing else in the suite reaches that
+# coercion: the screen short-circuits before the solver, so the tests around it
+# never let Z3 see a hazardous expression. If either test fails, Z3's behavior
+# changed and the screen's premise needs revisiting -- along with the
+# docstrings on `ConstraintSystem.check_satisfiability`,
+# `check_satisfiability_with_bindings`, and `_does_node_coerce_a_bool_operand`.
+# That is the reading; it is not a broken test.
+
+
+def test_z3_rewrites_a_bool_operand_compared_against_an_integer() -> None:
+    """Test Z3 rewrites a lowered `BoolVal` in a numeric comparison to `If(b, 1, 0)`.
+
+    A ``bool``-valued literal lowers to ``z3.BoolVal`` and an ``int``
+    literal to ``z3.IntVal``. Comparing the two does not raise: the
+    bindings insert the ``If(..., 1, 0)`` rewrite and report the
+    comparison satisfiable, identifying ``True`` with ``1``. This
+    package's literal semantics hold the two apart, so the lowering
+    cannot be trusted to answer for it.
+    """
+    comparison = BinaryExpression(
+        BinaryOperation.EQUAL, LiteralExpression(True), LiteralExpression(1)
+    )
+
+    lowered, _ = convert_expression_to_z3_expression(comparison, {})
+
+    coerced_operand = lowered.children()[0]
+    assert z3.is_app_of(coerced_operand, z3.Z3_OP_ITE)
+    assert str(coerced_operand) == "If(True, 1, 0)"
+    solver = z3.Solver()
+    solver.add(lowered)
+    assert solver.check() == z3.sat
+    assert not LiteralExpression(True).is_structurally_equivalent(LiteralExpression(1))
+
+
+def test_z3_bool_coercion_yields_a_model_this_package_rejects() -> None:
+    """Test the coercion produces a satisfying assignment equating `True` with `1`.
+
+    A ``SymbolType.BOOL`` identifier compared against an integer literal
+    is satisfiable under Z3, and the witness assigns the identifier
+    ``True`` -- Z3's answer to "can this Boolean equal 1?" is yes. Under
+    this package's type-strict literal semantics ``True`` and ``1`` are
+    distinct values, so a decided outcome read back from this lowering
+    would contradict the semantics the constraint layer promises.
+    """
+    variable = mock_identifier("b", 0)
+    comparison = BinaryExpression(
+        BinaryOperation.EQUAL, IdentifierExpression(variable), LiteralExpression(1)
+    )
+
+    lowered, identifier_to_z3_expression = convert_expression_to_z3_expression(
+        comparison, {variable: SymbolType.BOOL}
+    )
+
+    z3_variable = identifier_to_z3_expression[variable]
+    assert str(lowered.children()[0]) == f"If({z3_variable}, 1, 0)"
+    solver = z3.Solver()
+    solver.add(lowered)
+    assert solver.check() == z3.sat
+    assert z3.is_true(solver.model()[z3_variable])
+    assert not LiteralExpression(True).is_structurally_equivalent(LiteralExpression(1))


### PR DESCRIPTION
Constraints gain a bindings evaluation API (evaluate_with_bindings / is_satisfied_with_bindings over Mapping[Identifier, value]) with simultaneous substitution, making dependent constraints across several variables decidable. ConstraintSystem (create_constraint_system) is a canonically ordered conjunction with check_satisfiability / check_satisfiability_with_bindings deciding joint satisfiability through the solver seam as a tri-state ConstraintOutcome; a missing symbol type raises the registered MissingSymbolTypeError rather than KeyError, while a missing value binding stays UNDECIDED.

Set constraints store deduplicated raw member tuples (type-strict equality preserved through the private wrapping used for evaluation, rendering, and equivalence), so no public attribute exposes internal wrappers. Equation constraints guard the Z3 bool-literal coercion hazard by degrading to UNDECIDED. The shared mock_identifier fixture gains a content-deterministic repr matching the real Identifier so repr-based canonicalization is provable under test.